### PR TITLE
arcanoid CRT scanlines by pixel pitch; audio survives live reloads; dasbind proxies for cache-served registrars

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -1687,7 +1687,7 @@ def document_module_audio_boost(_root : string) {
         group_by_regex("PCM stream", mod, %regex~(append_to_pcm|append_box_to_pcm)$%%),
         group_by_regex("Decoding", mod, %regex~(decode_audio)$%%),
         group_by_regex("Sound ID", mod, %regex~(generate_sound_sid)$%%),
-        group_by_regex("Internal stream management", mod, %regex~(get_audio_command_stream|set_audio_thread_command_stream|get_sound_sid|set_sound_sid)$%%)
+        group_by_regex("Internal stream management", mod, %regex~(get_audio_command_stream|set_audio_thread_command_stream|adopt_audio_thread_command_stream|get_sound_sid|set_sound_sid)$%%)
     )
     document("Audio playback, mixing, 3D spatial audio, and effects", mod, "audio_boost.rst", groups)
 }

--- a/examples/daStrudel/strudel_live/main.das
+++ b/examples/daStrudel/strudel_live/main.das
@@ -132,9 +132,7 @@ var asch : AudioSystemChannels
 [export]
 def init() {
     print("daStrudel live\n")
-    if (get_audio_command_stream() == null) {
-        asch = audio_system_create()
-    }
+    asch = audio_live_system()
     load_samples()
     strudel_init(@@strudel_main)
     print("playing...\n")
@@ -149,7 +147,7 @@ def update() {
 def shutdown() {
     print("Shutting down...\n")
     strudel_shutdown()
-    audio_system_finalize(asch.command, asch.next_sid)
+    audio_live_finalize(asch)
 }
 
 // standalone mode (daslang.exe): the same exported trio in the canonical loop

--- a/examples/daStrudel/strudel_sf2_live/main.das
+++ b/examples/daStrudel/strudel_sf2_live/main.das
@@ -103,9 +103,7 @@ var asch : AudioSystemChannels
 
 [export]
 def init() {
-    if (get_audio_command_stream() == null) {
-        asch = audio_system_create()
-    }
+    asch = audio_live_system()
     if (!strudel_has_sf2()) {
         let sf2_path = find_sf2()
         if (!empty(sf2_path) && strudel_load_sf2(sf2_path)) {
@@ -129,7 +127,7 @@ def update() {
 def shutdown() {
     print("Shutting down...\n")
     strudel_shutdown()
-    audio_system_finalize(asch.command, asch.next_sid)
+    audio_live_finalize(asch)
 }
 
 // --- standalone mode (daslang.exe): the same exported trio, bounded 30-second run ---

--- a/examples/daStrudel/strudel_visualizer/main.das
+++ b/examples/daStrudel/strudel_visualizer/main.das
@@ -201,9 +201,7 @@ def init() { // nolint:STYLE038 — linear track-setup sequence
     }
     upload_font_texture(font)
     // audio
-    if (get_audio_command_stream() == null) {
-        asch = audio_system_create()
-    }
+    asch = audio_live_system()
     // load SF2 soundfont
     if (USE_SF2) {
         let sf2_path = find_sf2()
@@ -415,7 +413,7 @@ def update() { // nolint:STYLE037,STYLE038 — per-panel-kind dispatch over a GL
 def shutdown() {
     print("Shutting down...\n")
     strudel_shutdown()
-    audio_system_finalize(asch.command, asch.next_sid)
+    audio_live_finalize(asch)
     delete render_states
     delete audio_analyses
     delete drum_panel_states

--- a/examples/games/REVIEW.md
+++ b/examples/games/REVIEW.md
@@ -7,12 +7,13 @@
 drops a finding it used to report is a defect** - updating a constant so a check keeps
 matching the tree is not.
 
-**A `.das` a diff adds or edits beside a game declares `module <name> public`, never
+**A `.das` in a game's folder that declares a module declares `module <name> public`, never
 `shared`** - a shared module survives a live reload, and the late-bound GL calls inside it fail
 their second compile.
 
-**A shader a diff adds or edits in a game uses only GLSL ES 3.00 features** - the same file
-runs in the playground on WebGL2.
+**A diff that adds or edits a `[vertex_program]` or `[fragment_program]` function in a game,
+or any `def` such a function reaches directly or through another `def`, keeps that code inside
+GLSL ES 3.00** - the same file runs in the playground on WebGL2.
 
 **A colour attachment a diff creates or retypes in a format other than `GL_RGBA8` checks
 framebuffer completeness at creation and falls back to `GL_RGBA8` when the framebuffer is

--- a/examples/games/arcanoid/CLAUDE.md
+++ b/examples/games/arcanoid/CLAUDE.md
@@ -92,9 +92,11 @@ live_command name=cmd_reset_game                                # Reset the game
 
 ## Keyboard Controls
 
-- **Arrow keys**: Move paddle left/right
+- **Arrow keys** or **A** / **D**: Move paddle left/right
 - **Space**: Start game / launch ball / release sticky ball / restart after game over
 - **Escape**: Pause / unpause
+- **F1** / **F2**: Toggle the CRT present / the ambient-occlusion pass
+- **F3** / **F4**: Step the CRT scanline pitch down / up (framebuffer pixels per line, 2 to 8; the HUD shows it)
 
 ## Game States
 

--- a/examples/games/arcanoid/arcanoid_postfx.das
+++ b/examples/games/arcanoid/arcanoid_postfx.das
@@ -209,7 +209,13 @@ def fs_present_plain {
 //
 // p_params  = (curvature, scanline strength, mask strength, fringe)
 // p_params2 = (vignette, flicker, time, brightness)
-// p_params3 = (screen width, screen height, scanline count, corner rounding)
+// p_params3 = (screen width, screen height, scanline pitch in pixels, corner rounding)
+
+//! the box filter of one cosine cycle fraction: sin(pi x) / (pi x)
+def private sinc_pi(x : float) : float {
+    let px = abs(x) * 3.14159265
+    return px < 0.001 ? 1.0 : sin(px) / px
+}
 
 def private crt_warp(uv : float2; curvature : float) : float2 {
     let c = uv * 2.0 - float2(1.0)
@@ -236,11 +242,17 @@ def fs_present_crt {
     let g = texture(p_tex0, uv).y
     let b = texture(p_tex0, uv - radial * fringe).z
     var color = float3(r, g, b)
-    // scanlines follow the tube face (warped uv) at a count well under the pixel rows, so the
-    // beam profile is resolved rather than aliased into rings
-    let line = uv.y * p_params3.z
-    let scan = 0.5 + 0.5 * cos(line * 6.2831853)
-    color *= 1.0 - p_params.y * scan * scan
+    // scanlines follow the tube face (warped uv) at a fixed pitch in framebuffer pixels, so
+    // the beam reads the same at every window size; the beam profile scan^2 is
+    // 3/8 + cos/2 + cos(2x)/8, each harmonic box-filtered over the pixel row so a trough is
+    // never point-sampled into a black row where the pitch beats against the pixel grid
+    let lines = p_params3.y / p_params3.z
+    let c = p_uv * 2.0 - float2(1.0)
+    let dwarp = 1.0 + curvature * dot(c, c) + 2.0 * curvature * c.y * c.y
+    let cycles = dwarp / p_params3.z
+    let phase = uv.y * lines * 6.2831853
+    let scan2 = 0.375 + 0.5 * cos(phase) * sinc_pi(cycles) + 0.125 * cos(2.0 * phase) * sinc_pi(2.0 * cycles)
+    color *= 1.0 - p_params.y * scan2
     // aperture grille: three phosphor columns per triad, in screen pixels so it never moires
     let px = p_uv.x * p_params3.x
     let cell = floor(fract_local(px / 3.0) * 3.0)
@@ -480,7 +492,7 @@ struct PostSettings {
     vignette : float = 0.6
     flicker : float = 0.012
     brightness : float = 1.55
-    scanline_count : float = 480.0
+    scanline_pitch : float = 4.0     // framebuffer pixels per scanline
     corner : float = 0.04
     time : float = 0.0
     debug_view : int = 0            // 1: the occlusion buffer, 2: the normal-depth target
@@ -571,10 +583,9 @@ def run_postfx(cfg : PostSettings) {
     }
     if (cfg.crt && cfg.debug_view == 0) {
         glUseProgram(present_crt_program)
-        let lines = cfg.scanline_count
         p_params = float4(cfg.curvature, cfg.scanline, cfg.mask, cfg.fringe)
         p_params2 = float4(cfg.vignette, cfg.flicker, cfg.time, cfg.brightness)
-        p_params3 = float4(float(fx_width), float(fx_height), lines, cfg.corner)
+        p_params3 = float4(float(fx_width), float(fx_height), max(cfg.scanline_pitch, 1.0), cfg.corner)
         vs_post_bind_uniform(present_crt_program)
         fs_present_crt_bind_uniform(present_crt_program)
     } else {

--- a/examples/games/arcanoid/main.das
+++ b/examples/games/arcanoid/main.das
@@ -643,6 +643,8 @@ var space_was_pressed = false
 var esc_was_pressed = false
 var f1_was_pressed = false
 var f2_was_pressed = false
+var f3_was_pressed = false
+var f4_was_pressed = false
 var @live god_mode = false
 var @live game_speed = 1.0
 var @live prev_music_state = GameState.menu
@@ -954,14 +956,23 @@ def update_bot_paddle(dt : float) {
     }
 }
 
+// the arrows and A / D both steer, for the left hand
+def paddle_left_pressed() : bool {
+    return glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS || glfwGetKey(live_window, GLFW_KEY_A) == GLFW_PRESS
+}
+
+def paddle_right_pressed() : bool {
+    return glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS || glfwGetKey(live_window, GLFW_KEY_D) == GLFW_PRESS
+}
+
 def update_paddle(dt : float) {
     if (spectator) {
         update_bot_paddle(dt)
     } else {
-        if (glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS) {
+        if (paddle_left_pressed()) {
             paddle_x += PADDLE_SPEED * dt
         }
-        if (glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS) {
+        if (paddle_right_pressed()) {
             paddle_x -= PADDLE_SPEED * dt
         }
     }
@@ -1749,6 +1760,9 @@ def draw_hud() {
     }
     draw_text("LIVES: {lives}", HUD_MARGIN, 80, lives_color)
     draw_text("LEVEL {level + 1}", display_w - HUD_MARGIN - 130, 45, float3(0.9, 0.9, 0.95))
+    if (crt_enabled) {
+        draw_text("PITCH {crt_pitch} F3/F4", display_w - HUD_MARGIN - 230, 80, float3(0.6, 0.6, 0.7))
+    }
     if (level_card_timer > 0.0) {
         let fade = min(level_card_timer / 0.4, 1.0)
         draw_text_centered("LEVEL {level + 1}", cx, cy - 40, float3(1.0, 0.85, 0.3) * fade)
@@ -1789,8 +1803,8 @@ var asch : AudioSystemChannels
 def init() {
     live_create_window("Arcanoid", 1024, 768)
     create_gl_objects()
+    asch = audio_live_system()
     if (!audio_initialized) {
-        asch = audio_system_create()
         audio_initialized = true
         init_audio_samples()
     }
@@ -1845,8 +1859,8 @@ def update() {   // nolint:STYLE037,STYLE038 - one linear frame: input, simulati
     let esc_pressed = glfwGetKey(live_window, GLFW_KEY_ESCAPE) == GLFW_PRESS
     let esc_just = esc_pressed && !esc_was_pressed
     esc_was_pressed = esc_pressed
-    let left_pressed = glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS
-    let right_pressed = glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS
+    let left_pressed = paddle_left_pressed()
+    let right_pressed = paddle_right_pressed()
     let any_key = space_pressed || esc_pressed || left_pressed || right_pressed
     idle_timer = any_key ? 0.0 : idle_timer + dt
     // F1 and F2 toggle the CRT and the occlusion pass; they are looks, not play, so they leave a demo running
@@ -1858,8 +1872,19 @@ def update() {   // nolint:STYLE037,STYLE038 - one linear frame: input, simulati
     if (f2_pressed && !f2_was_pressed) {
         ssao_enabled = !ssao_enabled
     }
+    // F3 and F4 step the scanline pitch, a look knob for the CRT preview
+    let f3_pressed = glfwGetKey(live_window, GLFW_KEY_F3) == GLFW_PRESS
+    let f4_pressed = glfwGetKey(live_window, GLFW_KEY_F4) == GLFW_PRESS
+    if (f3_pressed && !f3_was_pressed) {
+        crt_pitch = max(crt_pitch - 0.5, 2.0)
+    }
+    if (f4_pressed && !f4_was_pressed) {
+        crt_pitch = min(crt_pitch + 0.5, 8.0)
+    }
     f1_was_pressed = f1_pressed
     f2_was_pressed = f2_pressed
+    f3_was_pressed = f3_pressed
+    f4_was_pressed = f4_pressed
     if (spectator) {
         attract_timer += dt
         let round_over = game_state == GameState.game_over_state || game_state == GameState.win_state
@@ -2021,12 +2046,14 @@ def update() {   // nolint:STYLE037,STYLE038 - one linear frame: input, simulati
 var @live crt_enabled = true
 var @live ssao_enabled = true
 var @live fx_debug_view = 0
+var @live crt_pitch = 4.0
 let FOV_Y = 45.0 * PI / 180.0
 
 def post_settings(aspect : float) : PostSettings {
     var cfg = PostSettings()
     cfg.crt = crt_enabled
     cfg.ssao = ssao_enabled
+    cfg.scanline_pitch = crt_pitch
     cfg.debug_view = fx_debug_view
     let t = tan(FOV_Y * 0.5)
     cfg.tan_half_fov = float2(t * aspect, t)
@@ -2065,7 +2092,7 @@ def shutdown() {
         strudel_shutdown()
         music_initialized = false
     }
-    audio_system_finalize(asch.command, asch.next_sid)
+    audio_live_finalize(asch)
     delete_gl_objects()
     live_destroy_window()
 }

--- a/examples/games/asteroids/main.das
+++ b/examples/games/asteroids/main.das
@@ -883,8 +883,8 @@ def process_collisions() {
 def init() {
     live_create_window("Asteroids", 1024, 768)
     create_gl_objects()
+    asch = audio_live_system()
     if (!audio_initialized) {
-        asch = audio_system_create()
         audio_initialized = true
         init_audio_samples()
     }
@@ -1068,10 +1068,7 @@ def shutdown() {
         strudel_shutdown()
         music_initialized = false
     }
-    if (audio_initialized) {
-        audio_system_finalize(asch.command, asch.next_sid)
-        audio_initialized = false
-    }
+    audio_live_finalize(asch)
     live_destroy_window()
 }
 

--- a/examples/games/boulder-dash/main.das
+++ b/examples/games/boulder-dash/main.das
@@ -856,8 +856,8 @@ def setup_camera() {
 def init() {
     live_create_window("Boulder Dash", 1280, 720)
     create_gl_objects()
+    asch = audio_live_system()
     if (!audio_initialized) {
-        asch = audio_system_create()
         audio_initialized = true
         init_audio_samples()
     }
@@ -882,7 +882,8 @@ def init() {
         music_initialized = true
         start_music_for_state()
     }
-    if (!is_reload()) {
+    // a full reload or a reset leaves the @live cave at its default, cells and all: generate as on a cold start
+    if (!is_reload() || empty(g_cave.cells)) {
         var next <- generate_cave(world_seed, cave_index)
         adopt_cave(g_cave, next)
         g_cave.god = god_mode
@@ -949,9 +950,7 @@ def shutdown() {
         strudel_shutdown()
         music_initialized = false
     }
-    if (!is_reload()) {
-        audio_system_finalize(asch.command, asch.next_sid)
-    }
+    audio_live_finalize(asch)
     live_destroy_window()
 }
 

--- a/examples/games/pacman/main.das
+++ b/examples/games/pacman/main.das
@@ -449,8 +449,8 @@ var @live pellets_eaten_total = 0
 // ===== Pellet state =====
 // Stored as flat arrays indexed by cell — simpler than DECS for a static maze
 
-var pellets     : array<bool>   // true = pellet present
-var power_pills : array<bool>   // true = power pill present
+var @live pellets     : array<bool>   // true = pellet present
+var @live power_pills : array<bool>   // true = power pill present
 
 def init_pellets() {
     pellets     |> resize(MAZE_COLS * MAZE_ROWS)
@@ -1113,8 +1113,8 @@ def reset_game() {
 def init() {
     live_create_window("Pac-Man", 900, 760)
     create_gl_objects()
+    asch = audio_live_system()
     if (!audio_initialized) {
-        asch = audio_system_create()
         audio_initialized = true
         init_audio_samples()
     }
@@ -1139,7 +1139,8 @@ def init() {
         music_initialized = true
         start_menu_music()
     }
-    if (!is_reload()) {
+    // a full reload or a reset leaves the @live pellet arrays at their default, empty: start as on a cold start
+    if (!is_reload() || empty(pellets)) {
         init_pellets()
         reset_pac()
         dot_counter = 0
@@ -1284,7 +1285,7 @@ def shutdown() {
         strudel_shutdown()
         music_initialized = false
     }
-    audio_system_finalize(asch.command, asch.next_sid)
+    audio_live_finalize(asch)
     live_destroy_window()
 }
 

--- a/examples/games/river_run/rr_globals.das
+++ b/examples/games/river_run/rr_globals.das
@@ -21,7 +21,6 @@ require live/live_vars public
 // skips re-spawning under is_reload(). The templates are all POD, so they
 // serialize cleanly.
 require live/decs_live public
-require live/audio_live public
 require audio/audio_boost public
 require strudel/strudel public
 require strudel/strudel_player public

--- a/examples/games/sequence/sfx.das
+++ b/examples/games/sequence/sfx.das
@@ -87,10 +87,8 @@ var private g_audio_channels : AudioSystemChannels
 // --- Init / Play ---
 
 def init_audio() {
-    if (!audio_initialized) {
-        g_audio_channels = audio_system_create()
-        audio_initialized = true
-    }
+    g_audio_channels = audio_live_system()
+    audio_initialized = true
     // init_audio re-runs on every live reload; release the buffers the previous run left behind
     delete snd_card_play
     delete snd_chip_place
@@ -127,7 +125,7 @@ def public sfx_shutdown() {
     if (!audio_initialized) {
         return
     }
-    audio_system_finalize(g_audio_channels.command, g_audio_channels.next_sid)
+    audio_live_finalize(g_audio_channels)
     delete snd_chip_place
     delete snd_chip_remove
     delete snd_card_play

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -232,7 +232,7 @@ namespace das {
         AstSerializer & serializeModule ( Module & module, bool already_exists );
 
         static constexpr uint32_t getVersion () {
-            return 208;   // 208: a node reference is the writer's first-mention number as a varint, not a pointer-and-epoch word (207: neither Function nor Variable flags carry a used bit, and neither streams an index; 206: the record header carries the requires the parse took; 205: a vector of a handled element streams under the element's module; 204: the record header stamps the source by content hash; the policy stream carries every CodeOfPolicies field)
+            return 209;   // 209: a record written by a recompile that served a dasbind registrar could carry a dependent's calls to the extern stubs unrewritten - the format is unchanged, the bump discards those records (208: a node reference is the writer's first-mention number as a varint, not a pointer-and-epoch word; 207: neither Function nor Variable flags carry a used bit, and neither streams an index; 206: the record header carries the requires the parse took; 205: a vector of a handled element streams under the element's module; 204: the record header stamps the source by content hash; the policy stream carries every CodeOfPolicies field)
         }
 
         void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept;

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -1293,7 +1293,13 @@ def public audio_system_create : AudioSystemChannels {
 
 [unused_argument(next_sid)]
 def public audio_system_finalize(var s : Stream?&; var next_sid : Atomic64?) {
-    //! Low-level: shuts down the audio system.
+    //! Low-level: shuts down the audio system. A null stream in the caller's copy - a reload
+    //! zeroed it, or init never reached audio_system_create - shuts down whatever the module
+    //! holds, so nothing stays up past the real shutdown.
+    if (s == null) {
+        s = g_command_stream
+    }
+    return if (s == null)
     s |> push_archive(AudioCommand(shutdown = true))
     unsafe(invoke_in_context(mixer_context(), "command_processor"))
     sound_finalize()
@@ -1656,6 +1662,16 @@ def public set_audio_thread_command_stream(ch : void?) {
     if (g_command_stream != null) {
         g_command_stream |> add_ref
     }
+}
+
+[unsafe_operation]
+def public adopt_audio_thread_command_stream(ch : void?) {
+    //! A reload's restore: the reference the old context's global held on the stream passes to
+    //! this context's global, none is taken - the old context is gone without a release, so
+    //! `set_audio_thread_command_stream` here would leave one reference per reload behind and
+    //! the real finalize would refuse to delete the stream. Its caller is the restore of a fresh
+    //! context, whose global holds nothing yet.
+    g_command_stream = unsafe(reinterpret<Stream?>(ch))
 }
 
 def public get_sound_sid : void ? {

--- a/modules/dasAudio/audio/audio_live.das
+++ b/modules/dasAudio/audio/audio_live.das
@@ -12,13 +12,24 @@ module audio_live shared public
 //! The opaque pointers (`Stream?`, `Atomic64?`) live in the C++ DLL and survive
 //! reload, but the daScript globals that reference them are lost. This module
 //! saves them as `uint64` via Archive before reload and restores them after
-//! reload using the add_ref/release-safe setters.
+//! reload; the stream's reference passes from the old context's global to the
+//! new one (`adopt_audio_thread_command_stream`), so a reload leaves the count
+//! where the real finalize expects it.
 
 require daslib/archive
+require jobque   //! the Stream and Atomic64 types audio_live_channels casts to
 require audio/audio_boost
 require live_host
 
 let private STORE_KEY = "__audio_live_handles"
+
+def public audio_live_keeps_handles : bool {
+    //! True in a shutdown() a reload runs - the audio system stays up and its handles carry
+    //! over (a reset and a full reload clear the store's data entries and keep its
+    //! infrastructure entries, the handles among them); false in the real shutdown. A program's
+    //! shutdown() finalizes the audio system exactly when this is false.
+    return is_reload()
+}
 
 [before_reload]
 def private save_audio_handles() {
@@ -34,6 +45,29 @@ def private save_audio_handles() {
     unsafe { delete ser; }
 }
 
+def public audio_live_channels : AudioSystemChannels {
+    //! The handles this module carried across the reload, for a program whose own copy
+    //! (the tuple `audio_system_create` answered) the reload zeroed.
+    return (
+        command = unsafe(reinterpret<Stream?>(get_audio_command_stream())),
+        next_sid = unsafe(reinterpret<Atomic64?>(get_sound_sid()))
+    )
+}
+
+def public audio_live_system : AudioSystemChannels {
+    //! The audio system a live program keeps: created on a cold start, the carried-over
+    //! handles after a reload. A program's init() assigns its channels from this.
+    return get_audio_command_stream() == null ? audio_system_create() : audio_live_channels()
+}
+
+def public audio_live_finalize(var channels : AudioSystemChannels) {
+    //! A program's shutdown() counterpart of audio_live_system: finalizes the audio system
+    //! at the real shutdown and leaves it up through a reload.
+    if (!audio_live_keeps_handles()) {
+        audio_system_finalize(channels.command, channels.next_sid)
+    }
+}
+
 [after_reload]
 def private restore_audio_handles() {
     var data : array<uint8>
@@ -45,7 +79,7 @@ def private restore_audio_handles() {
         arch |> serialize(cmd_ch)
         arch |> serialize(sid_ptr)
         unsafe {
-            set_audio_thread_command_stream(reinterpret<void?>(cmd_ch))
+            adopt_audio_thread_command_stream(reinterpret<void?>(cmd_ch))
             set_sound_sid(reinterpret<void?>(sid_ptr))
             delete ser
         }

--- a/site/REVIEW.md
+++ b/site/REVIEW.md
@@ -63,9 +63,9 @@ folder) against the branch tip, naming the passes and any failures; a later edit
 files restates the run.** The no-WASM lane cannot see a broken runtime path, and a run
 recorded mid-branch describes a tree that no longer ships.
 
-**A stated Playwright run names every playground sample the diff changed: for each, the spec
-that loaded it, or - when no spec loads it - that it was opened and run by hand in the
-playground.**
+**A stated Playwright run names every playground sample the diff changed (the samples are
+staged from `web/examples/ui/samples/`, repo root): for each, the spec that loaded it, or -
+when no spec loads it - that it was opened and run by hand in the playground.**
 
 **A stated Playwright run names the runtime artifacts it used: built from this change when
 the diff touches any source compiled into the WASM runtime (`daslang_static` - its `main()`

--- a/site/files/examples.js
+++ b/site/files/examples.js
@@ -21,7 +21,7 @@
             description: 'The classic block-breaker — paddle, ball, breakable rows, ' +
                 'rendered in 3D straight through the WebGL2 backend.',
             tags: ['game', 'opengl', 'wasm'],
-            controls: '← →  paddle · space launch',
+            controls: '← → or A D  paddle · space launch · F3 F4 scanline pitch',
             poster: 'files/examples/arcanoid-poster.png',
             aspect: 1024 / 768,           // native window — sizes the player so the game fills it
         },

--- a/src/builtin/ARCHITECTURE.md
+++ b/src/builtin/ARCHITECTURE.md
@@ -114,9 +114,25 @@ under distinct multipliers, so one argument in the wrong register or slot change
 `tests/dasbind/CMakeLists.txt` builds the probe on a 64-bit host that builds and dlopens a
 shared library at test time - not wasm, Android or iOS, none of which walks `tests/` - and
 `tests/.das_test` skips the suite only on a 32-bit host, where the probe is not built, and under
-dastest's `--ser`/`--deser` sweep, because a deserialized program never applies `[extern]` and
-so never manufactures the `__dasbind__` function it names in the `dasbind` module; a 64-bit
-desktop tree without the library fails the suite instead of skipping it.
+dastest's `--ser`/`--deser` sweep. A deserialized program never applies `[extern]`, while a
+deserialized call already names its `__dasbind__` function in the `dasbind` module - and only
+`apply` or a retarget manufactures that function. A 64-bit desktop tree without the library
+fails the suite instead of skipping it.
+
+The `__dasbind__` proxy - the `DasBindFunction` a call to an `[extern]` is retargeted to - is
+registered by the `[extern]` annotation's `apply` callback when the registrar - the module
+carrying the `[extern]` declarations - compiles, and on demand by `transformCall` when the
+`dasbind` module lacks it: the module cache serves a registrar in a process that already
+compiled it (a live reload - the same process, so the `dasbind` module's hash shows no drift and
+nothing reparses the registrar), or a fresh process reads a dependent's record before any
+compile applied the registrar. `transformCall` takes the bind name from the call target's own
+`[extern]` declaration every time (`bindNameOf`) - the one input every process has - rather than
+from a table keyed on the function object, which every deserialization mints anew and whose
+freed addresses a later compile reuses. The proxy's signature types are clones with no source
+location (`proxyType`): the declaration's types and file record belong to the registrar's
+compile, which a served registrar's program takes with it, while the proxy lives for the
+process. A failed bind on the on-demand path is the call's transform error, the diagnostic
+`apply` would have given.
 
 ## 4. A message that crosses the panic jump
 

--- a/src/builtin/REVIEW.md
+++ b/src/builtin/REVIEW.md
@@ -28,6 +28,12 @@
   else. A C++ layout change to a handled type or an AST class is not a record byte: functions
   and annotations stream by module hash and name and re-resolve against the running binary.
 
+- **A diff that makes a record written before it wrong - the bytes still decode, but what they
+  encode is no longer what this build would write - bumps the version `getVersion()` returns
+  in `include/daScript/ast/ast_serializer.h`, in the same change** - the version is the only
+  thing that discards a cache a user already holds, so without the bump every later launch is
+  served the stale record.
+
 - **A diff that streams or compares a `CodeOfPolicies` field in `module_builtin_ast_serialize.cpp`
   outside `DAS_MODULE_CACHE_POLICY_FIELDS` is a defect - put the field on the list instead** - the
   list drives both the record's policy stream and the compare that refuses a record written under
@@ -55,10 +61,11 @@
   hash, never the module an extern lives in, so a cached DLL binds the old name and crashes on
   the hit.
 
-- **A diff that changes the wrapper tables, the `systemV_extra` list, the arm64 layout or the
-  `das_arm64_call` trampoline updates section 3 of `ARCHITECTURE.md` in the same change.** Two
-  comments in `module_builtin_dasbind.cpp` cite that section instead of restating it, so a
-  stale section is what the next reader trusts.
+- **A diff that changes how an `[extern]` call reaches its bind - the wrapper tables, the
+  `systemV_extra` list, the arm64 layout, the `das_arm64_call` trampoline, or when and from
+  what the `__dasbind__` proxy is registered and the call retargeted - updates section 3 of
+  `ARCHITECTURE.md` in the same change.** Comments in `module_builtin_dasbind.cpp` cite that
+  section instead of restating it, so a stale section is what the next reader trusts.
 
 - **A diff that changes what `ModuleFileCache::defaultPath` folds into the module-cache key -
   the binary, the command line, the environment names, or which script arguments count - updates
@@ -91,7 +98,7 @@
   embedding one.** The exe bakes the host's `sizeof` for such a type, so a target that sizes an
   embedded member differently gives every das local of it the wrong length.
 
-- **A diff that changes the member order or member set of a C++ type das binds through an
-  annotation states its `--jit-check-abi` result for a cross target in its own PR
+- **A diff that changes the data-member order or data-member set of a C++ type das binds
+  through an annotation states its `--jit-check-abi` result for a cross target in its own PR
   description.** The check reports a mismatch at the bundle's first launch, for the types the
   bundle links; nothing native can observe one.

--- a/src/builtin/module_builtin_dasbind.cpp
+++ b/src/builtin/module_builtin_dasbind.cpp
@@ -548,7 +548,6 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
 
     struct ExternFunctionAnnotation : FunctionAnnotation {
         ExternFunctionAnnotation() : FunctionAnnotation("extern") { }
-        das_hash_map<const Function *, string> transformMap;
         virtual bool apply(ExprBlock *, ModuleGroup &, const AnnotationArgumentList &, string & err) override {
             err = "not supported for block";
             return false;
@@ -624,21 +623,39 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
             if ( !is_ok ) {
                 return false;
             }
+            return !registerProxy(fun, ba, err).empty();
+        }
+
+        // the proxy outlives the registrar's program: its types are clones, with no location
+        static TypeDeclPtr proxyType ( const TypeDeclPtr & type ) {
+            if ( !type ) return nullptr;
+            auto clone = new TypeDecl(*type);
+            clone->at = LineInfo();
+            clone->firstType = proxyType(type->firstType);
+            clone->secondType = proxyType(type->secondType);
+            for ( auto & argType : clone->argTypes ) {
+                argType = proxyType(argType);
+            }
+            return clone;
+        }
+
+        // registers the proxy a call to `fun` is retargeted to; the bind name, empty on failure
+        string registerProxy ( Function * fun, const ExternBindArgs & ba, string & err ) {
             // resolve DLL and create a BuiltInFunction proxy for JIT
             void * funptr = nullptr;
             string bindName = mangleFunction(ba.fn_name, ba.library, ba.api);
             if ( !ba.late && ba.api!=ApiType::api_opengl ) {
                 funptr = getDllAddress(ba.library, ba.fn_name, ba.api == ApiType::api_opengl, err);
-                if ( !funptr ) return false;
+                if ( !funptr ) return string();
             }
             auto wrp = computeWrapper(fun);
             uint64_t code = lateBind(ba.fn_name, ba.library, funptr);
             auto bif = new DasBindFunction(bindName, code, funptr, ba, wrp, computeArm64Layout(fun));
-            bif->result = fun->result;
+            bif->result = proxyType(fun->result);
             for ( auto & a : fun->arguments ) {
                 auto newArg = new Variable();
                 newArg->name = a->name;
-                newArg->type = a->type;
+                newArg->type = proxyType(a->type);
                 bif->arguments.push_back(newArg);
             }
             bif->noAot = true;
@@ -650,8 +667,37 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
             if ( !module->addFunction(bif, true) ) {
                 module->replaceFunction(bif);
             }
-            transformMap[fun] = bindName;
+            return bindName;
+        }
+
+        static bool sameSignature ( Function * proxy, Function * fun ) {
+            if ( proxy->arguments.size() != fun->arguments.size() ) return false;
+            if ( !proxy->result->isSameType(*fun->result, RefMatters::yes, ConstMatters::no, TemporaryMatters::no) ) return false;
+            for ( size_t i=0, is=fun->arguments.size(); i!=is; ++i ) {
+                if ( !proxy->arguments[i]->type->isSameType(*fun->arguments[i]->type, RefMatters::yes, ConstMatters::no, TemporaryMatters::no) ) return false;
+            }
             return true;
+        }
+
+        // the bind name from the call target's own [extern] declaration (a cache-served
+        // registrar never passed apply here), registering the proxy when the module lacks it;
+        // empty for a non-extern, empty with `err` set when the bind fails
+        string bindNameOf ( Function * fun, string & err ) {
+            for ( auto & decl : fun->annotations ) {
+                if ( decl->annotation != this ) continue;
+                auto [is_ok, ba] = parseExternArgs(decl->arguments, err);
+                if ( !is_ok ) return string();
+                string bindName = mangleFunction(ba.fn_name, ba.library, ba.api);
+                // one bind name per native symbol, one proxy per das signature
+                if ( auto proxies = module->functionsByName.find(hash64z(bindName.c_str())) ) {
+                    for ( auto * proxy : proxies->second ) {
+                        if ( sameSignature(proxy, fun) ) return bindName;
+                    }
+                }
+                if ( !verifyCallCorrect(fun, decl->arguments, err) ) return string();
+                return registerProxy(fun, ba, err);
+            }
+            return string();
         }
 
         static bool needWrapArg(ExpressionPtr arg) {
@@ -673,10 +719,11 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
             return false;
         }
 
-        virtual ExpressionPtr transformCall ( ExprCallFunc * call, string & ) override {
+        virtual ExpressionPtr transformCall ( ExprCallFunc * call, string & err ) override {
             if ( !call->func ) return nullptr;
-            auto it = transformMap.find(call->func);
-            bool hasBindFunction = it != transformMap.end();
+            string bindName = bindNameOf(call->func, err);
+            if ( !err.empty() ) return nullptr;    // the inferer reports it
+            bool hasBindFunction = !bindName.empty();
             // check if any string args need wrapping
             auto needToTransform = any_of(call->arguments.begin(), call->arguments.end(), [](ExpressionPtr arg) {
                 return needWrapArg(arg);
@@ -684,8 +731,8 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
             if ( !needToTransform && !hasBindFunction ) return nullptr;
             // clone call, optionally retargeting to the DasBindFunction
             ExpressionPtr newCallExpr = nullptr;
-            DAS_ASSERTF(hasBindFunction, "All dasbind functions should have been mapped, %s is not mapped somehow.", call->func->name.c_str());
-            newCallExpr = new ExprCall(call->at, it->second);
+            DAS_ASSERTF(hasBindFunction, "an [extern] call's bind name must resolve, %s has none.", call->func->name.c_str());
+            newCallExpr = new ExprCall(call->at, bindName);
             for ( auto & arg : call->arguments ) {
                 static_cast<ExprCall*>(newCallExpr)->arguments.push_back(arg->clone());
             }

--- a/tests-cpp/REVIEW.md
+++ b/tests-cpp/REVIEW.md
@@ -1,7 +1,7 @@
 # tests-cpp Code Review Checklist
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
-doc: `skills/internal/writing_cpp_tests.md` (repo root).
+doc: `skills/internal/writing_cpp_tests.md`.
 
 **A `*_pin.cpp` file, wherever the diff puts it, answers to the `small/` subfolder's
 checklist as well as this one.**
@@ -9,6 +9,6 @@ checklist as well as this one.**
 **A test that owns its own `CMakeLists.txt`, wherever the diff puts it, answers to the
 `big/` subfolder's checklist as well as this one.**
 
-**A diff adding or changing a C++ test under this folder that cannot fail on some lane - it
-skips there, or its subject compiles there to an implementation the test does not exercise - says
-in the PR which lane runs it for real, naming the command.**
+**A C++ test a diff adds or changes that some lane running the suite cannot fail on - the test
+skips there, or its subject sits behind a `#if` that lane leaves undefined - names in the PR
+the lanes that do run it, with the command.**

--- a/tests-cpp/small/REVIEW.md
+++ b/tests-cpp/small/REVIEW.md
@@ -1,7 +1,7 @@
 # tests-cpp/small Code Review Checklist
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
-doc: `skills/internal/writing_cpp_tests.md` (repo root).
+doc: `skills/internal/writing_cpp_tests.md`.
 
 **A diff that widens or removes a pin assertion also changes, in the same PR, what that
 assertion watches - the layout, offset, or file set the pin names.** A

--- a/tests-cpp/small/test_dasbind_cache_drv_a.das
+++ b/tests-cpp/small/test_dasbind_cache_drv_a.das
@@ -1,0 +1,9 @@
+options gen2
+options indenting = 4
+
+require test_dasbind_cache_reg
+
+[export]
+def probe : int {
+    return c_abs(-7)
+}

--- a/tests-cpp/small/test_dasbind_cache_drv_b.das
+++ b/tests-cpp/small/test_dasbind_cache_drv_b.das
@@ -1,0 +1,9 @@
+options gen2
+options indenting = 4
+
+require test_dasbind_cache_reg
+
+[export]
+def probe : int {
+    return c_abs(-9) + int(c_abs_bits(uint(-100)))
+}

--- a/tests-cpp/small/test_dasbind_cache_reg.das
+++ b/tests-cpp/small/test_dasbind_cache_reg.das
@@ -1,0 +1,17 @@
+options gen2
+options indenting = 4
+
+module test_dasbind_cache_reg public
+
+require dasbind public
+
+[extern(cdecl, name="abs", windows_library="msvcrt", linux_library="libc.so.6", macos_library="libSystem.B.dylib")]
+def c_abs(x : int) : int {
+    return 0
+}
+
+//! the same native symbol under a second das signature: one bind name, two proxies
+[extern(cdecl, name="abs", windows_library="msvcrt", linux_library="libc.so.6", macos_library="libSystem.B.dylib")]
+def c_abs_bits(x : uint) : uint {
+    return 0u
+}

--- a/tests-cpp/small/test_dasbind_cache_served_registrar.cpp
+++ b/tests-cpp/small/test_dasbind_cache_served_registrar.cpp
@@ -1,0 +1,103 @@
+// A dasbind registrar the module cache serves in a process that already compiled it
+// (a live reload after the cache warmed) still retargets a fresh dependent's calls to its
+// proxies. The registrar's [extern] apply ran in the first compile only; the served copy is
+// a new Function object, and a transformCall keyed on the object alone left the calls on
+// the stubs - a runtime "extern has no body" in the dependent, and a cache record carrying
+// the unrewritten calls to every later process.
+
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+#include "daScript/ast/ast_serializer.h"
+
+#include <cstdio>
+#include <cstring>
+
+using namespace das;
+
+// the subject lives behind DAS_BIND_EXTERNAL (das_config.h), and the fixture names its libc
+// through the platform-qualified library arguments parseExternArgs reads on MSVC, Apple and
+// Linux alone; elsewhere (a MinGW Windows build) [extern] has no library to bind
+#if DAS_BIND_EXTERNAL && (defined(_MSC_VER) || defined(__APPLE__) || defined(__linux__))
+
+namespace {
+
+struct ProbeRun {
+    bool        compiled = false;
+    bool        simulated = false;
+    bool        called = false;
+    int32_t     result = 0;
+    string      exception;
+    uint64_t    served = 0;
+    bool        wrote = false;
+};
+
+ProbeRun run_probe ( const string & script, const string & cachePath ) {
+    ProbeRun run;
+    TextPrinter tout;
+    ModuleFileCache cache;              // outlives the program: its FileInfos back the AST's LineInfos
+    ModuleGroup libGroup;
+    auto fAccess = make_smart<FsFileAccess>();
+    cache.install(cachePath, cachePath, false);
+    // the live host's policy: no promotion of shared modules, so the second compile walks
+    // the same module list the record stream carries instead of skipping the promoted ones
+    CodeOfPolicies policies;
+    policies.ignore_shared_modules = true;
+    auto program = compileDaScript(script, fAccess, tout, libGroup, policies);
+    run.compiled = !program->failed();
+    if ( run.compiled ) {
+        Context ctx(program->getContextStackSize());
+        run.simulated = program->simulate(ctx, tout);
+        auto res = cache.finish();
+        run.served = res.served;
+        run.wrote = res.wrote;
+        if ( run.simulated ) {
+            auto fn = ctx.findFunction("probe");
+            if ( fn ) {
+                run.called = ctx.runWithCatch([&]() {
+                    run.result = cast<int32_t>::to(ctx.eval(fn, nullptr));
+                });
+                if ( !run.called && ctx.getException() ) run.exception = ctx.getException();
+            }
+        }
+    } else {
+        cache.finish();
+    }
+    return run;
+}
+
+}
+
+TEST_CASE("dasbind: a registrar served from the module cache still retargets a fresh dependent") {
+    const string root = getDasRoot() + "/tests-cpp/small/";
+    const string cachePath = getDasRoot() + "/.jitted_scripts/tests_cpp_dasbind_cache.dascache";   // gitignored, outside the pruned default directory
+    remove(cachePath.c_str());
+
+    // cold: the registrar compiles from source, its apply registers the proxies, the cache is written
+    auto cold = run_probe(root + "test_dasbind_cache_drv_a.das", cachePath);
+    REQUIRE_MESSAGE(cold.compiled, "cold compile failed");
+    REQUIRE_MESSAGE(cold.simulated, "cold simulate failed");
+    CHECK_MESSAGE(cold.called, "cold call threw: " << cold.exception);
+    CHECK_EQ(cold.result, 7);
+    REQUIRE_MESSAGE(cold.wrote, "the cold compile wrote no cache");
+
+    // warm, in the same process: a different driver reparses, the registrar is served - its
+    // builtin hash matches the process that populated it, so no drift resume reparses it
+    auto warm = run_probe(root + "test_dasbind_cache_drv_b.das", cachePath);
+    REQUIRE_MESSAGE(warm.compiled, "warm compile failed");
+    REQUIRE_MESSAGE(warm.simulated, "warm simulate failed");
+    CHECK_MESSAGE(warm.served >= 1, "the warm compile served nothing from the cache");
+    CHECK_MESSAGE(warm.called, "warm call threw: " << warm.exception);
+    CHECK_EQ(warm.result, 109);
+
+    // a third compile reads the proxy the served registrar left in the dasbind module after
+    // its own program died: the proxy's types must be the module's, not that program's
+    auto again = run_probe(root + "test_dasbind_cache_drv_a.das", cachePath);
+    remove(cachePath.c_str());
+    REQUIRE_MESSAGE(again.compiled, "third compile failed");
+    REQUIRE_MESSAGE(again.simulated, "third simulate failed");
+    CHECK_MESSAGE(again.called, "third call threw: " << again.exception);
+    CHECK_EQ(again.result, 7);
+}
+
+#endif

--- a/tests/live_host/_fixture_audio_reload.das
+++ b/tests/live_host/_fixture_audio_reload.das
@@ -1,0 +1,36 @@
+options gen2
+options persistent_heap
+options gc
+options no_aot
+
+require live/live_api
+require live/live_vars
+require live/audio_live
+require audio/audio_boost
+require live_host
+
+//! The audio lifecycle a game runs under the live host: the system is created once, a reload,
+//! a full reload and a reset keep it and refill the program's handle copy, the real shutdown
+//! finalizes it. Every init pushes a command through the handles it holds, so a dead stream
+//! throws here.
+
+var asch : AudioSystemChannels
+var @live inits = 0
+
+[export]
+def init() {
+    let adopted = get_audio_command_stream() != null
+    asch = audio_live_system()
+    inits ++
+    to_log(LOG_INFO, "fixture: init {inits} adopted={adopted}\n")
+    set_global_volume(0.5)
+}
+
+[export]
+def update() {
+}
+
+[export]
+def shutdown() {
+    audio_live_finalize(asch)
+}

--- a/tests/live_host/_live_host_spawn.das
+++ b/tests/live_host/_live_host_spawn.das
@@ -1,0 +1,167 @@
+options gen2
+options no_aot
+options no_unused_block_arguments = false
+
+module _live_host_spawn public
+
+require daslib/fio
+require daslib/command_line
+require daslib/strings_boost
+require dashv/dashv_boost
+require strings
+
+//! The spawn helpers the tests of this folder share for a daslang-live child: the host beside
+//! the daslang running dastest, a free port of the span, the ready wait that drains stdout,
+//! the reload endpoints with their generation wait, and the exit wait.
+
+let PORT_FIRST = 19390
+let PORT_SPAN = 20
+
+//! the daslang-live beside the daslang running dastest; empty where the tree has not built it
+def live_exe() : string {
+    let beside = path_join(dir_name(get_full_file_name(get_das_exe())), "daslang-live{get_platform_name() == "windows" ? ".exe" : ""}")
+    return fexist(beside) ? beside : ""
+}
+
+//! the body of a 200 answer to GET /status, empty when nothing answers
+def status_body(port : int) : string {
+    var body = ""
+    with_http_request() $(var req) {
+        req.method = http_method.GET
+        req.url := "http://127.0.0.1:{port}/status"
+        request(req) $(resp) {
+            if (resp != null && int(resp.status_code) == 200) {
+                body = string(resp.body)
+            }
+        }
+    }
+    return body
+}
+
+def status_answers(port : int) : bool {
+    return !empty(status_body(port))
+}
+
+//! the first port from `from` to the end of the span no host answers on, so a /status answer is
+//! this test's own child and its /shutdown reaches nothing else; -1 when every port has a host
+def free_port_from(from : int) : int {
+    for (port in range(from, PORT_FIRST + PORT_SPAN)) {
+        if (!status_answers(port)) return port
+    }
+    return -1
+}
+
+def free_port() : int {
+    return free_port_from(PORT_FIRST)
+}
+
+//! spawns daslang-live on `script` with `extra_args` after the `--` on a free port and runs
+//! the block once /status answers, with the port and the seconds it took; two tests of a
+//! parallel suite can pick one free port at once and the loser's host ends at once on
+//! "already running", so an attempt whose child ends before it answers moves to the next
+//! free port, three attempts in all - the block then sees the last attempt, ready -1. The
+//! child is closed after the block; stdout is drained into `lines` throughout. False, with
+//! the block never run and a line in `lines`, when no port of the span is free
+def with_ready_host(exe, script : string; extra_args : array<string>; var lines : array<string>; blk : block<(var host : process; port : int; ready : float) : void>) : bool {
+    let no_env : array<string>
+    var from = PORT_FIRST
+    for (attempt in range(3)) {
+        let port = free_port_from(from)
+        if (port < 0) {
+            lines |> push("no free port from {from} to {PORT_FIRST + PORT_SPAN - 1}")
+            return false
+        }
+        var args <- [exe, "--live-port={port}", script]
+        args |> push_from(extra_args)
+        var host = unsafe(spawn_process(args, get_das_root(), no_env))
+        let ready = wait_ready(host, port, 30.0, lines)
+        if (ready >= 0.0 || attempt == 2) {
+            invoke(blk, host, port, ready)
+            unsafe {
+                close_process(host)   //! ends a child that never became ready
+            }
+            return true
+        }
+        unsafe {
+            close_process(host)
+        }
+        from = port + 1
+    }
+    return false
+}
+
+def post(port : int; path : string) {
+    with_http_request() $(var req) {
+        req.method = http_method.POST
+        req.url := "http://127.0.0.1:{port}{path}"
+        request(req) $(_resp) {
+        }
+    }
+}
+
+def post_shutdown(port : int) {
+    post(port, "/shutdown")
+}
+
+//! seconds until /status answers, draining the host's stdout meanwhile; -1 past the deadline
+//! or once the host is gone
+def wait_ready(var host : process; port : int; seconds : float; var lines : array<string>) : float {
+    let started = ref_time_ticks()
+    while (float(get_time_usec(started)) < seconds * 1000000.0) {
+        unsafe(process_drain(host) $(line) {
+            lines |> push(line)
+        })
+        if (unsafe(process_poll(host)) != process_running) return -1.0
+        if (status_answers(port)) return float(get_time_usec(started)) / 1000000.0
+        sleep(250u)
+    }
+    return -1.0
+}
+
+//! the reload generation /status reports, -1 when nothing answers
+def status_generation(port : int) : int {
+    let body = status_body(port)
+    return -1 if (empty(body))
+    let at = find(body, "\"generation\"")
+    return -1 if (at < 0)
+    let colon = find(body, ":", at)
+    return -1 if (colon < 0)
+    return to_int(strip(slice(body, colon + 1, find(body, "\n", colon))))
+}
+
+//! posts `path` and waits until /status reports `generation`, draining stdout meanwhile;
+//! false past the deadline or once the host is gone
+def post_and_wait_generation(var host : process; port : int; path : string; generation : int; seconds : float; var lines : array<string>) : bool {
+    post(port, path)
+    let started = ref_time_ticks()
+    while (float(get_time_usec(started)) < seconds * 1000000.0) {
+        unsafe(process_drain(host) $(line) {
+            lines |> push(line)
+        })
+        if (unsafe(process_poll(host)) != process_running) return false
+        if (status_generation(port) >= generation) return true
+        sleep(100u)
+    }
+    return false
+}
+
+//! the exit code once the host ends, draining its stdout meanwhile and once more after the exit -
+//! the lines the host writes last, its shutdown's exception and its leak census among them,
+//! land between the last drain and the poll that sees it gone; process_running past the deadline
+def wait_exit_draining(var host : process; seconds : float; var lines : array<string>) : int {
+    let started = ref_time_ticks()
+    while (float(get_time_usec(started)) < seconds * 1000000.0) {
+        unsafe(process_drain(host) $(line) {
+            lines |> push(line)
+        })
+        let rc = unsafe(process_poll(host))
+        if (rc != process_running) {
+            unsafe(process_drain(host) $(line) {
+                lines |> push(line)
+            })
+            return rc
+        }
+        sleep(20u)
+    }
+    return process_running
+}

--- a/tests/live_host/test_audio_reload.das
+++ b/tests/live_host/test_audio_reload.das
@@ -1,0 +1,62 @@
+options gen2
+options no_aot
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require daslib/fio
+require daslib/command_line
+require daslib/strings_boost
+require daslib/rtti
+require _live_host_spawn
+require strings
+
+//! The audio system a program created survives a reload, a full reload and a reset under the
+//! live host: the program's shutdown() leaves it up (audio_live_keeps_handles), audio_live
+//! carries the handles over with the old context's reference, and the next init() pushes
+//! through them; the real shutdown finalizes it once. None of it throws, and nothing is left
+//! in the job-status census the host prints at exit.
+
+def private lines_mention(lines : array<string>; needle : string) : bool {
+    for (line in lines) {
+        return true if (find(line, needle) >= 0)
+    }
+    return false
+}
+
+[test]
+def test_audio_survives_reloads(t : T?) {
+    if (!has_module("audio")) {
+        t |> skip("no audio module in this build")
+        return
+    }
+    let exe = live_exe()
+    if (empty(exe)) {
+        t |> skip("no daslang-live beside {get_das_exe()}")
+        return
+    }
+    if (free_port() < 0) {
+        t |> skip("a host answers on every port from {PORT_FIRST} to {PORT_FIRST + PORT_SPAN - 1}")
+        return
+    }
+    t |> run("two reloads, a full reload and a reset keep the audio system up, and /shutdown leaves nothing") @(t : T?) {
+        let script = path_join(get_das_root(), "tests/live_host/_fixture_audio_reload.das")
+        var lines : array<string>
+        let spawned = with_ready_host(exe, script, ["--", "--null-audio"], lines) $(var host; port; ready) {
+            t |> success(ready >= 0.0, "daslang-live did not serve /status within 30 s:\n{join(lines, "\n")}")
+            if (ready >= 0.0) {
+                var generation = 0
+                for (path in ["/reload", "/reload", "/reload/full", "/reset"]) {
+                    generation ++
+                    let done = post_and_wait_generation(host, port, path, generation, 30.0, lines)
+                    t |> success(done, "{path} did not complete within 30 s:\n{join(lines, "\n")}")
+                }
+                post_shutdown(port)
+                let rc = wait_exit_draining(host, 20.0, lines)
+                t |> equal(rc, 0, "the host exited with 0 after /shutdown:\n{join(lines, "\n")}")
+                t |> success(!lines_mention(lines, "EXCEPTION"), "a lifecycle call threw:\n{join(lines, "\n")}")
+                t |> success(!lines_mention(lines, "leaked JobStatus"), "the host left a stream or status behind:\n{join(lines, "\n")}")
+            }
+        }
+        t |> success(spawned, "no port to spawn on:\n{join(lines, "\n")}")
+    }
+}

--- a/tests/live_host/test_host_ready.das
+++ b/tests/live_host/test_host_ready.das
@@ -6,81 +6,13 @@ require dastest/testing_boost public
 require daslib/fio
 require daslib/command_line
 require daslib/strings_boost
-require dashv/dashv_boost
+require _live_host_spawn
 require strings
 
 //! daslang-live serves its HTTP API on the port its argv names. The host reads the LiveHost
 //! shared module's lifecycle exports before any require names that module, so a module scan
 //! that defers it has to bring it in first - otherwise live mode never turns on, no server
 //! starts, and every client waits out its ready budget.
-
-let PORT_FIRST = 19390
-let PORT_SPAN = 20
-
-//! the daslang-live beside the daslang running dastest; empty where the tree has not built it
-def private live_exe() : string {
-    let beside = path_join(dir_name(get_full_file_name(get_das_exe())), "daslang-live{get_platform_name() == "windows" ? ".exe" : ""}")
-    return fexist(beside) ? beside : ""
-}
-
-def private status_answers(port : int) : bool {
-    var ok = false
-    with_http_request() $(var req) {
-        req.method = http_method.GET
-        req.url := "http://127.0.0.1:{port}/status"
-        request(req) $(resp) {
-            ok = resp != null && int(resp.status_code) == 200
-        }
-    }
-    return ok
-}
-
-//! the first port of the span no host answers on, so a /status answer is this test's own child
-//! and its /shutdown reaches nothing else; -1 when every port has a host
-def private free_port() : int {
-    for (port in range(PORT_FIRST, PORT_FIRST + PORT_SPAN)) {
-        if (!status_answers(port)) return port
-    }
-    return -1
-}
-
-def private post_shutdown(port : int) {
-    with_http_request() $(var req) {
-        req.method = http_method.POST
-        req.url := "http://127.0.0.1:{port}/shutdown"
-        request(req) $(_resp) {
-        }
-    }
-}
-
-//! seconds until /status answers, draining the host's stdout meanwhile; -1 past the deadline
-//! or once the host is gone
-def private wait_ready(var host : process; port : int; seconds : float; var lines : array<string>) : float {
-    let started = ref_time_ticks()
-    while (float(get_time_usec(started)) < seconds * 1000000.0) {
-        unsafe(process_drain(host) $(line) {
-            lines |> push(line)
-        })
-        if (unsafe(process_poll(host)) != process_running) return -1.0
-        if (status_answers(port)) return float(get_time_usec(started)) / 1000000.0
-        sleep(250u)
-    }
-    return -1.0
-}
-
-//! the exit code once the host ends, draining its stdout meanwhile; process_running past the deadline
-def private wait_exit_draining(var host : process; seconds : float; var lines : array<string>) : int {
-    let started = ref_time_ticks()
-    while (float(get_time_usec(started)) < seconds * 1000000.0) {
-        unsafe(process_drain(host) $(line) {
-            lines |> push(line)
-        })
-        let rc = unsafe(process_poll(host))
-        if (rc != process_running) return rc
-        sleep(20u)
-    }
-    return process_running
-}
 
 [test]
 def test_host_serves_status(t : T?) {
@@ -89,25 +21,22 @@ def test_host_serves_status(t : T?) {
         t |> skip("no daslang-live beside {get_das_exe()}")
         return
     }
-    let port = free_port()
-    if (port < 0) {
+    if (free_port() < 0) {
         t |> skip("a host answers on every port from {PORT_FIRST} to {PORT_FIRST + PORT_SPAN - 1}")
         return
     }
     t |> run("/status answers within the ready budget, and /shutdown ends the host with 0") @(t : T?) {
         let script = path_join(get_das_root(), "tests/live_host/_fixture_host_ready.das")
-        let no_env : array<string>
-        var host = unsafe(spawn_process([exe, "--live-port={port}", script], get_das_root(), no_env))
+        let no_args : array<string>
         var lines : array<string>
-        let ready = wait_ready(host, port, 30.0, lines)
-        t |> success(ready >= 0.0, "daslang-live did not serve /status within 30 s:\n{join(lines, "\n")}")
-        if (ready >= 0.0) {
-            post_shutdown(port)
-            let rc = wait_exit_draining(host, 20.0, lines)
-            t |> equal(rc, 0, "the host exited with 0 after /shutdown:\n{join(lines, "\n")}")
+        let spawned = with_ready_host(exe, script, no_args, lines) $(var host; port; ready) {
+            t |> success(ready >= 0.0, "daslang-live did not serve /status within 30 s:\n{join(lines, "\n")}")
+            if (ready >= 0.0) {
+                post_shutdown(port)
+                let rc = wait_exit_draining(host, 20.0, lines)
+                t |> equal(rc, 0, "the host exited with 0 after /shutdown:\n{join(lines, "\n")}")
+            }
         }
-        unsafe {
-            close_process(host)   //! ends a child that never became ready
-        }
+        t |> success(spawned, "no port to spawn on:\n{join(lines, "\n")}")
     }
 }

--- a/tutorials/daStrudel/daStrudel_16_live_reloading.das
+++ b/tutorials/daStrudel/daStrudel_16_live_reloading.das
@@ -153,9 +153,7 @@ var asch : AudioSystemChannels
 [export]
 def init() {
     print("daStrudel tutorial 16 — live reload\n")
-    if (get_audio_command_stream() == null) {
-        asch = audio_system_create()
-    }
+    asch = audio_live_system()
     load_samples()
     strudel_init(@@strudel_main)
     print("playing — edit this file and save to hot-reload the pattern!\n")
@@ -170,7 +168,7 @@ def update() {
 def shutdown() {
     print("shutdown\n")
     strudel_shutdown()
-    audio_system_finalize(asch.command, asch.next_sid)
+    audio_live_finalize(asch)
 }
 
 // Standalone fallback — if run under daslang.exe, drive the same exported trio

--- a/web/examples/ui/REVIEW.md
+++ b/web/examples/ui/REVIEW.md
@@ -11,14 +11,23 @@ puts it.**
 deploy copies these files into the site (`.github/workflows/pages.yml`, repo root), so
 `site/playground/` never shows the change.
 
-**A PR whose diff changes `src/` (this folder) or `samples/` states, in the PR body, a run of
-the WASM-staged Playwright suite (`site/tests/playground/`, repo root) against the branch tip,
-naming the passes and any failures; a later edit to those folders restates the run.** The
-no-WASM lane cannot see a broken runtime path, and a run recorded mid-branch describes a tree
-that no longer ships.
+**A PR whose diff changes `src/` (this folder) states, in the PR body, a run of the
+WASM-staged Playwright suite (`site/tests/playground/`, repo root) against the branch tip,
+naming the passes and any failures; a later edit to `src/` restates the run.** The no-WASM
+lane cannot see a broken runtime path, and a run recorded mid-branch describes a tree that no
+longer ships.
 
-**A `.das` file under `samples/` not written in gen2, or not a full program that compiles and
-runs with the current toolchain, is a defect.**
+**A PR whose diff changes a bundle under `samples/` - the file set a `data.json` entry lists -
+states, in the PR body, a run that loaded that bundle on a runtime built from the branch tip -
+the dasweb-verify browser run (`utils/internal/dasweb-verify`, repo root), or the bundle's game
+card or playground page opened and run for a few frames - naming the bundle and the
+artifact.** The Playwright suite stubs the graphics and audio bundles, so a green suite says
+nothing about them.
+
+**A `.das` under `samples/` not written in gen2 is a defect.**
+
+**A bundle under `samples/` that does not compile and run with the current toolchain is a
+defect.**
 
 **Never write a `// verify:` line into a `.das` file under `samples/` - put the budget or the expected pattern
 in `utils/internal/dasweb-verify/browser/expectations.json` instead.**

--- a/web/examples/ui/samples/examples/arcanoid/arcanoid_postfx.das
+++ b/web/examples/ui/samples/examples/arcanoid/arcanoid_postfx.das
@@ -209,7 +209,13 @@ def fs_present_plain {
 //
 // p_params  = (curvature, scanline strength, mask strength, fringe)
 // p_params2 = (vignette, flicker, time, brightness)
-// p_params3 = (screen width, screen height, scanline count, corner rounding)
+// p_params3 = (screen width, screen height, scanline pitch in pixels, corner rounding)
+
+//! the box filter of one cosine cycle fraction: sin(pi x) / (pi x)
+def private sinc_pi(x : float) : float {
+    let px = abs(x) * 3.14159265
+    return px < 0.001 ? 1.0 : sin(px) / px
+}
 
 def private crt_warp(uv : float2; curvature : float) : float2 {
     let c = uv * 2.0 - float2(1.0)
@@ -236,11 +242,17 @@ def fs_present_crt {
     let g = texture(p_tex0, uv).y
     let b = texture(p_tex0, uv - radial * fringe).z
     var color = float3(r, g, b)
-    // scanlines follow the tube face (warped uv) at a count well under the pixel rows, so the
-    // beam profile is resolved rather than aliased into rings
-    let line = uv.y * p_params3.z
-    let scan = 0.5 + 0.5 * cos(line * 6.2831853)
-    color *= 1.0 - p_params.y * scan * scan
+    // scanlines follow the tube face (warped uv) at a fixed pitch in framebuffer pixels, so
+    // the beam reads the same at every window size; the beam profile scan^2 is
+    // 3/8 + cos/2 + cos(2x)/8, each harmonic box-filtered over the pixel row so a trough is
+    // never point-sampled into a black row where the pitch beats against the pixel grid
+    let lines = p_params3.y / p_params3.z
+    let c = p_uv * 2.0 - float2(1.0)
+    let dwarp = 1.0 + curvature * dot(c, c) + 2.0 * curvature * c.y * c.y
+    let cycles = dwarp / p_params3.z
+    let phase = uv.y * lines * 6.2831853
+    let scan2 = 0.375 + 0.5 * cos(phase) * sinc_pi(cycles) + 0.125 * cos(2.0 * phase) * sinc_pi(2.0 * cycles)
+    color *= 1.0 - p_params.y * scan2
     // aperture grille: three phosphor columns per triad, in screen pixels so it never moires
     let px = p_uv.x * p_params3.x
     let cell = floor(fract_local(px / 3.0) * 3.0)
@@ -480,7 +492,7 @@ struct PostSettings {
     vignette : float = 0.6
     flicker : float = 0.012
     brightness : float = 1.55
-    scanline_count : float = 480.0
+    scanline_pitch : float = 4.0     // framebuffer pixels per scanline
     corner : float = 0.04
     time : float = 0.0
     debug_view : int = 0            // 1: the occlusion buffer, 2: the normal-depth target
@@ -571,10 +583,9 @@ def run_postfx(cfg : PostSettings) {
     }
     if (cfg.crt && cfg.debug_view == 0) {
         glUseProgram(present_crt_program)
-        let lines = cfg.scanline_count
         p_params = float4(cfg.curvature, cfg.scanline, cfg.mask, cfg.fringe)
         p_params2 = float4(cfg.vignette, cfg.flicker, cfg.time, cfg.brightness)
-        p_params3 = float4(float(fx_width), float(fx_height), lines, cfg.corner)
+        p_params3 = float4(float(fx_width), float(fx_height), max(cfg.scanline_pitch, 1.0), cfg.corner)
         vs_post_bind_uniform(present_crt_program)
         fs_present_crt_bind_uniform(present_crt_program)
     } else {

--- a/web/examples/ui/samples/examples/arcanoid/main.das
+++ b/web/examples/ui/samples/examples/arcanoid/main.das
@@ -643,6 +643,8 @@ var space_was_pressed = false
 var esc_was_pressed = false
 var f1_was_pressed = false
 var f2_was_pressed = false
+var f3_was_pressed = false
+var f4_was_pressed = false
 var @live god_mode = false
 var @live game_speed = 1.0
 var @live prev_music_state = GameState.menu
@@ -954,14 +956,23 @@ def update_bot_paddle(dt : float) {
     }
 }
 
+// the arrows and A / D both steer, for the left hand
+def paddle_left_pressed() : bool {
+    return glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS || glfwGetKey(live_window, GLFW_KEY_A) == GLFW_PRESS
+}
+
+def paddle_right_pressed() : bool {
+    return glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS || glfwGetKey(live_window, GLFW_KEY_D) == GLFW_PRESS
+}
+
 def update_paddle(dt : float) {
     if (spectator) {
         update_bot_paddle(dt)
     } else {
-        if (glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS) {
+        if (paddle_left_pressed()) {
             paddle_x += PADDLE_SPEED * dt
         }
-        if (glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS) {
+        if (paddle_right_pressed()) {
             paddle_x -= PADDLE_SPEED * dt
         }
     }
@@ -1749,6 +1760,9 @@ def draw_hud() {
     }
     draw_text("LIVES: {lives}", HUD_MARGIN, 80, lives_color)
     draw_text("LEVEL {level + 1}", display_w - HUD_MARGIN - 130, 45, float3(0.9, 0.9, 0.95))
+    if (crt_enabled) {
+        draw_text("PITCH {crt_pitch} F3/F4", display_w - HUD_MARGIN - 230, 80, float3(0.6, 0.6, 0.7))
+    }
     if (level_card_timer > 0.0) {
         let fade = min(level_card_timer / 0.4, 1.0)
         draw_text_centered("LEVEL {level + 1}", cx, cy - 40, float3(1.0, 0.85, 0.3) * fade)
@@ -1789,8 +1803,8 @@ var asch : AudioSystemChannels
 def init() {
     live_create_window("Arcanoid", 1024, 768)
     create_gl_objects()
+    asch = audio_live_system()
     if (!audio_initialized) {
-        asch = audio_system_create()
         audio_initialized = true
         init_audio_samples()
     }
@@ -1845,8 +1859,8 @@ def update() {   // nolint:STYLE037,STYLE038 - one linear frame: input, simulati
     let esc_pressed = glfwGetKey(live_window, GLFW_KEY_ESCAPE) == GLFW_PRESS
     let esc_just = esc_pressed && !esc_was_pressed
     esc_was_pressed = esc_pressed
-    let left_pressed = glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS
-    let right_pressed = glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS
+    let left_pressed = paddle_left_pressed()
+    let right_pressed = paddle_right_pressed()
     let any_key = space_pressed || esc_pressed || left_pressed || right_pressed
     idle_timer = any_key ? 0.0 : idle_timer + dt
     // F1 and F2 toggle the CRT and the occlusion pass; they are looks, not play, so they leave a demo running
@@ -1858,8 +1872,19 @@ def update() {   // nolint:STYLE037,STYLE038 - one linear frame: input, simulati
     if (f2_pressed && !f2_was_pressed) {
         ssao_enabled = !ssao_enabled
     }
+    // F3 and F4 step the scanline pitch, a look knob for the CRT preview
+    let f3_pressed = glfwGetKey(live_window, GLFW_KEY_F3) == GLFW_PRESS
+    let f4_pressed = glfwGetKey(live_window, GLFW_KEY_F4) == GLFW_PRESS
+    if (f3_pressed && !f3_was_pressed) {
+        crt_pitch = max(crt_pitch - 0.5, 2.0)
+    }
+    if (f4_pressed && !f4_was_pressed) {
+        crt_pitch = min(crt_pitch + 0.5, 8.0)
+    }
     f1_was_pressed = f1_pressed
     f2_was_pressed = f2_pressed
+    f3_was_pressed = f3_pressed
+    f4_was_pressed = f4_pressed
     if (spectator) {
         attract_timer += dt
         let round_over = game_state == GameState.game_over_state || game_state == GameState.win_state
@@ -2021,12 +2046,14 @@ def update() {   // nolint:STYLE037,STYLE038 - one linear frame: input, simulati
 var @live crt_enabled = true
 var @live ssao_enabled = true
 var @live fx_debug_view = 0
+var @live crt_pitch = 4.0
 let FOV_Y = 45.0 * PI / 180.0
 
 def post_settings(aspect : float) : PostSettings {
     var cfg = PostSettings()
     cfg.crt = crt_enabled
     cfg.ssao = ssao_enabled
+    cfg.scanline_pitch = crt_pitch
     cfg.debug_view = fx_debug_view
     let t = tan(FOV_Y * 0.5)
     cfg.tan_half_fov = float2(t * aspect, t)
@@ -2065,7 +2092,7 @@ def shutdown() {
         strudel_shutdown()
         music_initialized = false
     }
-    audio_system_finalize(asch.command, asch.next_sid)
+    audio_live_finalize(asch)
     delete_gl_objects()
     live_destroy_window()
 }

--- a/web/examples/ui/samples/examples/boulder-dash/main.das
+++ b/web/examples/ui/samples/examples/boulder-dash/main.das
@@ -856,8 +856,8 @@ def setup_camera() {
 def init() {
     live_create_window("Boulder Dash", 1280, 720)
     create_gl_objects()
+    asch = audio_live_system()
     if (!audio_initialized) {
-        asch = audio_system_create()
         audio_initialized = true
         init_audio_samples()
     }
@@ -882,7 +882,8 @@ def init() {
         music_initialized = true
         start_music_for_state()
     }
-    if (!is_reload()) {
+    // a full reload or a reset leaves the @live cave at its default, cells and all: generate as on a cold start
+    if (!is_reload() || empty(g_cave.cells)) {
         var next <- generate_cave(world_seed, cave_index)
         adopt_cave(g_cave, next)
         g_cave.god = god_mode
@@ -949,9 +950,7 @@ def shutdown() {
         strudel_shutdown()
         music_initialized = false
     }
-    if (!is_reload()) {
-        audio_system_finalize(asch.command, asch.next_sid)
-    }
+    audio_live_finalize(asch)
     live_destroy_window()
 }
 

--- a/web/examples/ui/samples/examples/pacman/main.das
+++ b/web/examples/ui/samples/examples/pacman/main.das
@@ -449,8 +449,8 @@ var @live pellets_eaten_total = 0
 // ===== Pellet state =====
 // Stored as flat arrays indexed by cell — simpler than DECS for a static maze
 
-var pellets     : array<bool>   // true = pellet present
-var power_pills : array<bool>   // true = power pill present
+var @live pellets     : array<bool>   // true = pellet present
+var @live power_pills : array<bool>   // true = power pill present
 
 def init_pellets() {
     pellets     |> resize(MAZE_COLS * MAZE_ROWS)
@@ -1113,8 +1113,8 @@ def reset_game() {
 def init() {
     live_create_window("Pac-Man", 900, 760)
     create_gl_objects()
+    asch = audio_live_system()
     if (!audio_initialized) {
-        asch = audio_system_create()
         audio_initialized = true
         init_audio_samples()
     }
@@ -1139,7 +1139,8 @@ def init() {
         music_initialized = true
         start_menu_music()
     }
-    if (!is_reload()) {
+    // a full reload or a reset leaves the @live pellet arrays at their default, empty: start as on a cold start
+    if (!is_reload() || empty(pellets)) {
         init_pellets()
         reset_pac()
         dot_counter = 0
@@ -1284,7 +1285,7 @@ def shutdown() {
         strudel_shutdown()
         music_initialized = false
     }
-    audio_system_finalize(asch.command, asch.next_sid)
+    audio_live_finalize(asch)
     live_destroy_window()
 }
 

--- a/web/examples/ui/samples/examples/river_run/rr_globals.das
+++ b/web/examples/ui/samples/examples/river_run/rr_globals.das
@@ -21,7 +21,6 @@ require live/live_vars public
 // skips re-spawning under is_reload(). The templates are all POD, so they
 // serialize cleanly.
 require live/decs_live public
-require live/audio_live public
 require audio/audio_boost public
 require strudel/strudel public
 require strudel/strudel_player public


### PR DESCRIPTION
**Behavior change: a program that requires `live/audio_live` keeps its audio system up across a live reload - its `shutdown()` finalizes the system only when `audio_live_keeps_handles()` is false. The nine in-tree clients are converted; an out-of-tree one that still finalizes on reload crashes on the first sound after it, as before.**

**Why.** The site's Arkanoid card drew 480 CRT scanlines over a 554-row canvas, a 1.15 px pitch past Nyquist, and the curvature warp swept the alias through zero along rings - the black circular bands on the card that fullscreen hid. On the way, a live reload of the game crashed in `Stream::push`, and a changed module beside a cache-served dasbind registrar left its extern calls on the stubs and wrote them into the cache.

**What changes.**
- The scanline period is a pitch in framebuffer pixels (`scanline_pitch`, default 4; F3/F4 step it, the HUD shows it), and the beam profile's two harmonics are box-filtered over the pixel row from the warp's closed-form derivative.
- A/D steer the paddle beside the arrows; the card's controls line names both.
- `audio_live` carries the audio system across a reload, a full reload and a reset: the restore adopts the old context's stream reference instead of taking one, and `audio_system_finalize` on a null copy shuts down what the module holds.
- A live program's init and shutdown become `asch = audio_live_system()` and `audio_live_finalize(asch)`: create or adopt, finalize only at the real shutdown. Every in-tree `audio_live` client uses them; river_run, whose design tears audio down on reload, no longer requires the module.
- Pacman's pellet arrays are `@live`; pacman and boulder-dash regenerate board state when a full reload or reset left it empty.
- `transformCall` takes an `[extern]` call's bind name from the callee's own declaration and registers the `__dasbind__` proxy when the module lacks it, with cloned, location-free signature types; the serializer version is 209, discarding records written with unrewritten calls.

**Observable behavior.**
- Arkanoid card at any canvas size: concentric dark rings -> clean scanlines at the same pitch everywhere.
- daslang-live reload of arcanoid, pacman, boulder-dash, asteroids, sequence, the three daStrudel examples, the live-reload tutorial: crash or exception at shutdown -> reload, full reload and reset all survive, shutdown leaves no stream behind.
- A live reload that changes a module beside a cache-served `[extern]` registrar: `a dasbind extern has no body to call` at the first call, cached for every later launch -> the call reaches its bind.
- A failed bind reached through a served registrar: an assertion or a call to an empty name -> the compile error `apply` would have given.

**Where to look.** `fs_present_crt` in `arcanoid_postfx.das` for the filter; `bindNameOf`/`registerProxy`/`proxyType` in `module_builtin_dasbind.cpp` and section 3 of `src/builtin/ARCHITECTURE.md` for the on-demand registration; `audio_live.das` and `audio_system_finalize` for the reload contract, with the games' `init`/`shutdown` as its consumers.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The site card was reproduced and verified locally: the wasm64 arcanoid, pacman and boulder-dash cards were built from this tree (`daspkg release wasm`) and run in the site's own player page served from a staged copy of `site/`; the rings are gone, A/D and F3/F4 work, pacman and boulder-dash start. The interpreted playground arm could not be run on this change: the deployed runtime lacks the new audio_live public, and a local wasm32 `daslang_static` build clobbers the tree's native archives; the Playwright suite stubs these three bundles regardless.
- Live-host reload, full reload and reset were driven by hand on arcanoid, pacman, boulder-dash, asteroids, river_run, `strudel_live` and the live-reload tutorial, each followed by a shutdown with no exception and no leaked job status. `tests/live_host/test_audio_reload.das` mechanizes the sequence on a fixture; it fails on the previous restore with `stream being deleted while being used`.
- `tests-cpp/small/test_dasbind_cache_served_registrar.cpp` runs for real on every per-PR lane that runs `ctest -L small` on MSVC x64, macOS and Linux; it is compiled out on 32-bit Windows and on MinGW, where `[extern]` has no library to bind (`parseExternArgs` reads the platform library arguments on MSVC, Apple and Linux). It fails on the previous `module_builtin_dasbind.cpp` with `a dasbind extern has no body to call`.
- The dupes gate (`make-pr --only dupes`) did not run: its corpus export dies on `examples/games/sequence/modules/das-cards/cards/svg_path.das:51` (a pre-existing syntax error, also on master) whenever a diff touches `examples/games`.
- `preflight --full` ran once: 23 gates green, two red. `tests-jit` red on one test, `tests/live_host/test_host_ready.das`, whose host died with `another instance of daslang-live is already running on port 19390` - the new audio reload test in a parallel worker picked the same free port; the spawn helper now moves to the next free port when the child ends before it answers, and the live_host suite passes interpreted and twice in parallel isolated JIT mode. `utils-tests` red on the `utils/mcp` suite's process exit, `1 smart pointer(s) still alive at shutdown - Context clone`, after all 477 tests passed; the suite standalone and the whole `run_utils_tests` target rerun green (exit 0), so it is read as a teardown flake under the full chain's load. Neither gate was rerun in full.
- Docs: `das2rst` regenerated with the new audio public grouped; `sphinx-build -W` succeeded.

### Claims - stated, not tested
- A proxy's signature types are cloned without a source location, so a served registrar's program can die while the proxy lives; a struct, enum or handled type inside such a signature still points at that program's declaration. No in-tree `[extern]` carries one, and a later compile's call would not match the stale proxy's types; a break reads as `no matching function` for the `__dasbind__` name.
- Registering a proxy on demand folds its name into the `dasbind` module hash when the name is new to the process, as `apply` does; the on-demand path only runs when the module lacks the name, so a stream's later records see the same hash a cold compile leaves. A break reads as every later record of a stream reparsing in place, `-module-cache <path>` printing the drift line per run.

### Not done
- The F3/F4 keys are Mission Control and Spotlight on a Mac without the Fn setting, and F3 opens the find bar in browsers; the card names them anyway.
- At pitch 2 (the F3 floor) the tube edge is still past Nyquist with the default curvature; a faint ring beat remains there. The default 4 is clean everywhere.
- A `REVIEW.das` gate for the audio reload contract (a game that requires `live/audio_live` and calls `audio_system_finalize` guards it with `audio_live_keeps_handles`, and gates `audio_system_create` on the module holding no stream) is a lint candidate, not written.

</details>
