### PR TITLE
the wasm toolchain roll ships the archives it just built, and the roll runs at all

### DIFF
--- a/examples/REVIEW.md
+++ b/examples/REVIEW.md
@@ -1,0 +1,14 @@
+# examples Code Review Checklist
+
+**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.**
+
+**A `.das` in this folder tree that a game's `main.das` requires, directly or through another
+required file, answers to `games/REVIEW.md` too - wherever the diff puts it.**
+
+**A folder with a `web_shell.html`, and every `.das` and `models.json` in it, answers to
+`dasLLAMA/REVIEW.md` too, wherever the diff puts it.**
+
+**A diff that drops `require live/audio_live` from a program states, in the PR body, why that
+program's audio is meant to die with a reload** - `audio_live` is what carries the audio
+thread's stream and channels across a reload, so without it the program creates and finalizes
+its own audio system on every one.

--- a/modules/dasAudio/ARCHITECTURE.md
+++ b/modules/dasAudio/ARCHITECTURE.md
@@ -31,6 +31,19 @@ wait gave up. Do not "fix" a timeout path by freeing there.
 `SeqBox` is the exception and is released on both paths: its holders drop references in any order
 and the last one deletes, so it needs no agreement with the audio thread.
 
+## audio_live owns the audio system across a reload
+
+Under `daslang-live` the host runs the program's `shutdown()` on every reload and `init()`
+after it, while `audio/audio_live.das` carries the audio thread's command stream and channels
+across the reload by adopting the old context's reference - the stream itself keeps mixing.
+`audio_live_system()` creates the system on the first `init()` and adopts it on every later one;
+`audio_live_finalize()` finalizes only at the real shutdown. A live program that calls
+`audio_system_create`, `audio_system_finalize` or `set_audio_thread_command_stream` itself
+breaks that in one of two ways: a finalize on reload frees the stream the restore is about to
+push through, and a `set_` on reload takes a reference per reload that the real finalize can
+never drop. `REVIEW.das` reports those calls in any program that requires `live/audio_live`;
+a program whose reload design tears audio down drops the require instead.
+
 ## The waits cascade
 
 `strudel_init` spawns the worker; the worker runs the caller's function, which calls

--- a/modules/dasAudio/REVIEW.das
+++ b/modules/dasAudio/REVIEW.das
@@ -1,0 +1,59 @@
+options gen2
+
+require strings
+require daslib/strings_boost
+require daslib/fio
+require dastest/review_gate
+
+// The mechanical half of modules/dasAudio/REVIEW.md (contract: REVIEW_COMMON.md at the repo root).
+// Run from the repo root: bin/daslang modules/dasAudio/REVIEW.das - exit 0 clean, 1 with findings.
+
+// Where programs that require live/audio_live live.
+let ROOTS <- ["examples", "tutorials", "modules", "tests", "utils"]
+
+let LIVE_MODULE = "live/audio_live"
+
+// The calls audio_live.das makes on a live program's behalf (ARCHITECTURE.md, "audio_live owns
+// the audio system across a reload"); audio_live.das itself does not require its own module.
+let RAW_CALLS <- ["audio_system_create(", "audio_system_finalize(", "set_audio_thread_command_stream("]
+
+def private walk_das(root : string; var out : array<string>) {
+    dir(root) $(name) {
+        return if (name |> starts_with("."))
+        let p = path_join(root, name)
+        let st = stat(p)
+        return if (!st.is_valid)
+        if (st.is_dir) {
+            walk_das(p, out)
+        } elif (name |> ends_with(".das")) {
+            out |> push(p)
+        }
+    }
+}
+
+def private check_live_clients {
+    var files : array<string>
+    for (root in ROOTS) {
+        walk_das(root, files)
+    }
+    files |> sort
+    for (path in files) {
+        continue if (find_index(das_requires(path), LIVE_MODULE) < 0)
+        let text = strip_line_comments(fread(path))
+        for (call in RAW_CALLS) {
+            let line = find_line(text, call)
+            continue if (line == 0)
+            gate_finding(path, line, "a program that requires {LIVE_MODULE} calls {call}...) directly; under a reload that tears down or double-references the stream audio_live carries over - use audio_live_system() / audio_live_finalize(), or drop the require when this program's audio is meant to die with a reload")
+        }
+    }
+}
+
+[export]
+def main : int {
+    if (!fexist("modules/dasAudio/REVIEW.das")) {
+        to_log(LOG_ERROR, "modules/dasAudio/REVIEW.das: run from the repo root\n")
+        return 2
+    }
+    check_live_clients()
+    return gate_verdict("modules/dasAudio/REVIEW.das")
+}

--- a/modules/dasAudio/REVIEW.md
+++ b/modules/dasAudio/REVIEW.md
@@ -1,0 +1,7 @@
+# dasAudio Code Review Checklist
+
+**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture doc:
+`ARCHITECTURE.md`.
+
+**A diff that makes `REVIEW.das` (beside this file) report less - fewer roots walked, fewer calls
+reported, more exempt paths, a deleted or loosened check - is a defect.**

--- a/modules/dasLLAMA/followup_general.md
+++ b/modules/dasLLAMA/followup_general.md
@@ -1530,3 +1530,11 @@
     words and selects with a dynamic vector index plus a byte shift. Unquirked: the emitter
     lowers a `let` fixed_array of literals to a constant-storage array, or a lint flags a
     dynamically indexed fixed_array local inside a kernel class.
+
+137. **The toolchain roll carries its own copy of dasImgui's wasm archive list.** Step 4 of
+    `utils/internal/dasweb-buildd/roll_toolchain.sh` repeats the `emcmake` build command and the
+    archive names that `modules/dasImgui/.das_package` declares (`release_wasm_build`,
+    `release_wasm_archive`), minus `liblibDasModuleClipboard.a`, which `daspkg build --wasm`
+    stages; a pairing rule in the folder's `REVIEW.md` is what keeps the two copies equal. The
+    fix is one source, not a second check: the roll runs the package's own wasm build - a daspkg
+    entry point that reads the manifest and bakes what it declares - and the copied list goes.

--- a/utils/REVIEW.md
+++ b/utils/REVIEW.md
@@ -12,7 +12,9 @@ every tool that requires it. An arm is one `t |> run(...)` case of a `[test]` fu
 arm's load-bearing assertions are the ones that prove the change, never a skip-path assertion.
 A CI row is a workflow step whose command runs the arm, directly or through a process it
 spawns. An assertion no CI row can run is one no CI row would execute: either no CI row runs
-the arm, or the arm returns or skips before the assertion. One arm can hold both kinds.
+the arm, or the arm returns or skips before the assertion. An arm that skips unless a host
+tool is present is runnable when the pull-request lane's runner image carries that tool, and
+the change names that lane. One arm can hold both kinds.
 
 **A changed file that belongs to a tool, wherever the tool sits, is reviewed with that tool's
 own `REVIEW.md`, where one exists, as well as with this checklist.**

--- a/utils/daspkg/README.md
+++ b/utils/daspkg/README.md
@@ -213,15 +213,14 @@ The **package runner** compiles `.das_package` scripts in-process using `compile
 
 ### Wasm archive staging {#wasm-archive-staging}
 
-The wasm build and a desktop build of the same tree write their module archives to the same
-`<das_root>/lib` names, and `build --wasm` stages them from there. Once a desktop build has
-written those names the wasm build stops replacing them - its build directory finds the outputs
-already up to date and skips the targets - so a plain stage copies native archives and
-`release wasm` then fails to link on every module symbol. Staging therefore identifies each
-module archive by content rather than by name - it walks the archive's members to the first
-object and asks for the wasm magic - and refuses a native one, naming the desktop build in the
-error. The runtime archive is staged from the web build's own output directory, which a desktop
-build never writes.
+The web build pins every archive it produces - the runtime and each module - into its own
+output directory, `web/output64/lib` (`das_pin_wasm_archives` in `web/CMakeLists.txt`), and
+`build --wasm` stages from there alone. `<das_root>/lib` belongs to the desktop build and is
+never read: an archive found there is stale by construction - a wasm archive an earlier web
+configure wrote, or a native one - and staging it over the fresh build ships old code under the
+new toolchain id. Staging still identifies each archive by content - it walks the archive's
+members to the first object and asks for the wasm magic - and refuses a native one, so a web
+build directory configured for another target is caught before `release wasm` fails to link.
 
 ## Tests
 

--- a/utils/daspkg/REVIEW.md
+++ b/utils/daspkg/REVIEW.md
@@ -64,6 +64,7 @@ in `test_daspkg_git.das`.
 a name a `.das_package` or the command line supplied, a CPU class, a companion's script path -
 outside `commands.das`, or without an `is_safe_pkg_name` check first - on the whole string,
 or on each `/`-separated segment when the string is a path declared to reach another tree,
-where a `..` segment passes - is a defect** - `is_safe_pkg_name` is private to `commands.das`,
-and a string carrying a space, a quote, a separator or `..` splits the command or reads
-outside the directory the path was built for.
+where a `..` segment passes - is a defect; a directory the command line names as an input or
+output root is not such a string** - `is_safe_pkg_name` is private to `commands.das`, and a
+string carrying a space, a quote, a separator or `..` splits the command or reads outside the
+directory the path was built for.

--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -1050,7 +1050,7 @@ def cmd_build(root : string; is_global : bool = false) {
 // (default <das_root>/web/output64/lib). Requires an activated emscripten SDK
 // (emcc + cmake on PATH); CI activates emsdk_env before invoking.
 [arch(at="README.md#wasm-archive-staging")]
-def cmd_build_wasm(_root : string; lib_dir_override : string) : int { // nolint:STYLE038 — the wasm build recipe: flat tool-invocation steps, one per stage
+def cmd_build_wasm(_root : string; lib_dir_override : string) : int {
     let das_root = get_das_root()
     let lib_dir = empty(lib_dir_override) ? "{das_root}/web/output64/lib" : lib_dir_override
     let build_dir = "{das_root}/web/build64"
@@ -1086,41 +1086,37 @@ def cmd_build_wasm(_root : string; lib_dir_override : string) : int { // nolint:
         return 1
     }
 
-    // Consolidate every produced archive into one canonical lib_dir so
-    // `release wasm` resolves them in one place. The web build splits outputs:
-    // the runtime lands in web/output64/lib (DAS_WEB_OUTPUT_DIR), the module
-    // archives in <das_root>/lib.
+    // The web build pins every archive - runtime and modules - into {out_dir}/lib
+    // (das_pin_wasm_archives in web/CMakeLists.txt); <das_root>/lib belongs to the
+    // desktop build and is never read here.
+    let copied = stage_wasm_archives("{out_dir}/lib", lib_dir)
+    if (copied < 0) return 1
+    if (copied == 0) {
+        to_log(LOG_ERROR, "build --wasm: build succeeded but no archives found under {out_dir}/lib\n")
+        return 1
+    }
+    log("build --wasm: {copied} archive(s) -> {lib_dir}\n")
+    return 0
+}
+
+//! Stages the runtime and module archives of `src_dir` into `lib_dir` and returns how many
+//! there are; the same directory counts without copying. -1 when one is not a wasm archive or
+//! a copy fails. Other archives beside them (freetype, the dasImgui bake) are left alone.
+def stage_wasm_archives(src_dir, lib_dir : string) : int {
     mkdir_rec(lib_dir)
     var copied = 0
-    var copy_failed = false
-    // Runtime archive (web/output64/lib via DAS_WEB_OUTPUT_DIR).
-    let rt_src = "{out_dir}/lib/liblibDaScript_runtime.a"
-    if (fexist(rt_src)) {
-        let rt_dst = path_join(lib_dir, "liblibDaScript_runtime.a")
-        if (get_full_file_name(rt_src) == get_full_file_name(rt_dst)) {
-            copied ++
-        } else {
-            var err : string
-            if (copy_file(rt_src, rt_dst, true, err)) {
-                copied ++
-                log("  staged liblibDaScript_runtime.a\n")
-            } else {
-                to_log(LOG_ERROR, "build --wasm: copy_file({rt_src} -> {rt_dst}) failed: {err}\n")
-                copy_failed = true
-            }
-        }
-    }
-    // Module archives (<das_root>/lib).
-    glob("{das_root}/lib", "**/liblibDasModule*.a") $(rel_path, is_dir) {
-        if (is_dir) return
+    var failed = false
+    glob(src_dir, "*.a") $(rel_path, is_dir) {
+        return if (is_dir)
         let base = base_name(rel_path)
-        let src = path_join("{das_root}/lib", rel_path)
-        let dst = path_join(lib_dir, base)
+        return if (base != "liblibDaScript_runtime.a" && !starts_with(base, "liblibDasModule"))
+        let src = path_join(src_dir, rel_path)
         if (!looks_like_wasm_archive(src)) {
-            to_log(LOG_ERROR, "build --wasm: {src} is not a wasm archive - this tree also has a desktop build; delete lib/liblibDasModule*.a and rerun\n")
-            copy_failed = true
+            to_log(LOG_ERROR, "build --wasm: {src} is not a wasm archive - the web build directory was configured for another target; delete it and rerun\n")
+            failed = true
             return
         }
+        let dst = path_join(lib_dir, base)
         if (get_full_file_name(src) == get_full_file_name(dst)) {
             copied ++
             return
@@ -1128,19 +1124,13 @@ def cmd_build_wasm(_root : string; lib_dir_override : string) : int { // nolint:
         var err : string
         if (!copy_file(src, dst, true, err)) {
             to_log(LOG_ERROR, "build --wasm: copy_file({src} -> {dst}) failed: {err}\n")
-            copy_failed = true
+            failed = true
             return
         }
         copied ++
         log("  staged {base}\n")
     }
-    if (copy_failed) return 1
-    if (copied == 0) {
-        to_log(LOG_ERROR, "build --wasm: build succeeded but no archives found under {build_dir}\n")
-        return 1
-    }
-    log("build --wasm: {copied} archive(s) -> {lib_dir}\n")
-    return 0
+    return failed ? -1 : copied
 }
 
 //! the 8-byte wasm module magic ("\0asm" + version 1) at `at`

--- a/utils/daspkg/test_daspkg.das
+++ b/utils/daspkg/test_daspkg.das
@@ -2729,3 +2729,30 @@ def test_wasm_archive_detection(t : T?) {
         force_rmdir(root)
     }
 }
+
+[test]
+def test_wasm_archive_staging(t : T?) {
+    t |> run("build --wasm stages the runtime and module archives of the web build's lib dir and nothing else") @(t : T?) {
+        let tmp = create_temp_directory_result("daspkg staging ")
+        if (!(tmp is value)) {
+            t |> failure("could not create temp directory: {tmp as error}")
+            return
+        }
+        let root = tmp as value
+        let web_lib = path_join(root, "web_lib")
+        let dst = path_join(root, "dst")
+        mkdir_rec(web_lib)
+        let wasm_magic <- [0x00u8, 0x61u8, 0x73u8, 0x6du8, 0x01u8, 0x00u8, 0x00u8, 0x00u8]
+        let native_magic <- [0xcfu8, 0xfau8, 0xedu8, 0xfeu8, 0x0cu8, 0x00u8, 0x00u8, 0x01u8]
+        write_archive(path_join(web_lib, "liblibDaScript_runtime.a"), wasm_magic)
+        write_archive(path_join(web_lib, "liblibDasModuleGlfw.a"), wasm_magic)
+        write_archive(path_join(web_lib, "libfreetype.a"), native_magic)   // a third-party bake beside them
+        t |> equal(stage_wasm_archives(web_lib, dst), 2, "the runtime and the module archive are staged")
+        t |> success(fexist(path_join(dst, "liblibDaScript_runtime.a")) && fexist(path_join(dst, "liblibDasModuleGlfw.a")), "both land in the lib dir")
+        t |> success(!fexist(path_join(dst, "libfreetype.a")), "an archive that is neither runtime nor module is left where it is")
+        t |> equal(stage_wasm_archives(web_lib, web_lib), 2, "the same directory counts without copying")
+        write_archive(path_join(web_lib, "liblibDasModuleNative.a"), native_magic)
+        t |> equal(stage_wasm_archives(web_lib, dst), -1, "a native archive among them refuses the stage")
+        force_rmdir(root)
+    }
+}

--- a/utils/internal/dasweb-buildd/README.md
+++ b/utils/internal/dasweb-buildd/README.md
@@ -152,7 +152,10 @@ warms it outside the sandbox with one build of **each** mode, because the page r
 ./roll_toolchain.sh --green       # roll to the newest master commit whose CI is green
 ```
 
-It refuses to start if the worktree has modified tracked files, and reports the old and new id.
+A tracked file that differs from HEAD only in its line endings was rewritten by a build - a
+generated `.das.inc` committed with the other ending - and the roll puts it back before moving;
+any other modified tracked file is a hand edit and the roll refuses to start. It reports the old
+and new id.
 Verify afterwards with the browser leg of `utils/internal/dasweb-verify`, which drives the live site.
 
 **Nightly, gated on green.** A toolchain left behind master compiles every sample with old
@@ -182,7 +185,9 @@ journalctl -u dasweb-buildd-roll.service -n 50      # last night's roll
 
 `--green` reads the public Actions API unauthenticated (60 requests an hour; one per commit
 walked, at most 30) and needs `jq` on the box. `test_roll_toolchain.das` drives the green
-predicate through `--green-check <runs.json>`, one recorded run shape per branch of the rule.
+predicate through `--green-check <runs.json>`, one recorded run shape per branch of the rule,
+and the worktree guard through `--dirty-check <worktree>`, which settles the named worktree the
+way a roll would - restores line-ending-only rewrites, exits 12 on a real edit - and stops.
 
 ## Tests
 

--- a/utils/internal/dasweb-buildd/REVIEW.md
+++ b/utils/internal/dasweb-buildd/REVIEW.md
@@ -1,7 +1,7 @@
 # dasweb-buildd Code Review Checklist
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture doc:
-`README.md`.
+`README.md`. Planned work: `modules/dasLLAMA/followup_general.md` (repo root).
 
 **Never put a `[test]` file under the global `tests/` tree, and never register one in a
 `CMakeLists.txt` - a `[test]` file for this directory lives here and requires its siblings by
@@ -71,16 +71,17 @@ re-queues jobs from builders that died - is not a resolution.
 
 **Never retain a route callback with `emplace` - use `push` instead.**
 
-**A diff that changes the behavior of a file in this folder other than a `.das` source or its
-test also documents that change in `README.md` - in the section covering that file, or in a new
-section for it - in the same change.**
+**A diff that adds or changes a command-line mode of `run_build.sh` or `roll_toolchain.sh`, or
+what one of their steps does, also documents it in `README.md` - in the section covering that
+file, or in a new section for it - in the same change.**
 
 **A diff that changes a build command line in `run_build.sh` also updates the matching
 cache-warming build in `roll_toolchain.sh`, in the same change.**
 
 **Never let a toolchain roll (`roll_toolchain.sh`) move the worktree without also rebuilding
-`bin/daslang` - the host compiler that emits the emcc link line - and
-`web/output64/lib/*_runtime*.a`.**
+`bin/daslang`, `web/output64/lib/*_runtime*.a`, and `web/output64/lib/liblib*Imgui*.a`.**
+`bin/daslang` is the host compiler that emits the emcc link line, and `daspkg build --wasm` does
+not build `liblib*Imgui*.a`.
 
 **Never let a roll step decide to skip itself by reading the worktree's HEAD alone - it skips
 only on a marker the roll writes after its last step.** A roll that dies after the checkout
@@ -90,10 +91,8 @@ leaves HEAD at the target with nothing rebuilt.
 the same change.**
 
 **A diff that changes the wasm-archive step's build command or archive list in
-`roll_toolchain.sh`, or `modules/dasImgui/.das_package`, also changes the other to match, in
-the same change.**
-
-**The wasm-archive list in `roll_toolchain.sh` never carries `liblibDasModuleClipboard.a`.**
+`roll_toolchain.sh`, or `modules/dasImgui/.das_package`, also changes the other to match in the
+same change, minus `liblibDasModuleClipboard.a`, which `daspkg build --wasm` stages.**
 
 **Never ship a file an operator edits on the box with plain `release_include` - use
 `release_include_if_missing`, so an upgrade keeps the operator's edits.**

--- a/utils/internal/dasweb-buildd/roll_toolchain.sh
+++ b/utils/internal/dasweb-buildd/roll_toolchain.sh
@@ -30,6 +30,12 @@
 #                                       exit 0 when the Actions runs in the file
 #                                       make a commit green, 1 otherwise; touches
 #                                       nothing (the predicate's test seam)
+#   ./roll_toolchain.sh --dirty-check <worktree>
+#                                       settle that worktree the way a roll would
+#                                       before moving it - restore tracked files a
+#                                       build rewrote with the other line ending,
+#                                       exit 12 on any real edit - and stop (the
+#                                       guard's test seam)
 #   ./roll_toolchain.sh --dry-run       print the plan, touch nothing
 #   ./roll_toolchain.sh --skip-restart  build and warm, leave the service alone
 #
@@ -62,6 +68,7 @@ REF=""
 GREEN=0
 IF_CHANGED=0
 GREEN_CHECK=""
+DIRTY_CHECK=0
 DRY_RUN=0
 SKIP_RESTART=0
 
@@ -71,6 +78,7 @@ while [ $# -gt 0 ]; do
         --green)        GREEN=1; shift ;;
         --if-changed)   IF_CHANGED=1; shift ;;
         --green-check)  GREEN_CHECK="${2:?--green-check needs a runs.json path}"; shift 2 ;;
+        --dirty-check)  DIRTY_CHECK=1; WORKTREE="${2:?--dirty-check needs a worktree path}"; shift 2 ;;
         --dry-run)      DRY_RUN=1; shift ;;
         --skip-restart) SKIP_RESTART=1; shift ;;
         -h|--help)      awk 'NR > 1 && /^#/ { print; next } NR > 1 { exit }' "$0"; exit 0 ;;
@@ -119,20 +127,41 @@ if [ -n "$GREEN_CHECK" ]; then
     exit $?
 fi
 
+# A tracked file that differs from HEAD only in its line endings was rewritten by
+# a build (a generated .das.inc committed with the other ending), and is put back.
+# Any other tracked-file change is a hand edit: rolling would silently discard or
+# preserve it, so the roll refuses. Untracked build dirs are expected and fine.
+settle_worktree() {
+    local f edits=""
+    while IFS= read -r -d '' f; do
+        if git diff --quiet --ignore-cr-at-eol -- "$f"; then
+            echo "restoring $f: it differs from HEAD in line endings only, a build rewrote it"
+            run git checkout -- "$f"
+        else
+            edits="$edits  $f"$'\n'
+        fi
+    done < <(git diff --name-only -z)
+    while IFS= read -r -d '' f; do
+        edits="$edits  $f (staged)"$'\n'
+    done < <(git diff --cached --name-only -z)
+    [ -z "$edits" ] && return 0
+    echo "worktree has modified tracked files — resolve before rolling:" >&2
+    printf '%s' "$edits" >&2
+    return 12
+}
+
 # .git is a FILE in a linked worktree (a gitdir pointer), so ask git itself.
 git -C "$WORKTREE" rev-parse --git-dir >/dev/null 2>&1 \
     || { echo "no git worktree at $WORKTREE" >&2; exit 10; }
+if [ "$DIRTY_CHECK" = 1 ]; then
+    cd "$WORKTREE"
+    settle_worktree
+    exit $?
+fi
 [ -f "$EMSDK_ROOT/emsdk_env.sh" ] || { echo "no emsdk at $EMSDK_ROOT" >&2; exit 11; }
 
 cd "$WORKTREE"
-
-# Tracked-file changes mean someone edited the toolchain by hand; rolling would
-# silently discard or preserve them. Untracked build dirs are expected and fine.
-if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-    echo "worktree has modified tracked files — resolve before rolling:" >&2
-    git status --short --untracked-files=no >&2
-    exit 12
-fi
+settle_worktree || exit $?
 
 OLD_ID="$(git rev-parse HEAD)"
 # Fetch even under --dry-run: it only moves remote-tracking refs, and without it

--- a/utils/internal/dasweb-buildd/test_roll_toolchain.das
+++ b/utils/internal/dasweb-buildd/test_roll_toolchain.das
@@ -5,19 +5,60 @@ require daslib/fio
 require daslib/strings_boost
 require strings
 
-//! The green predicate of roll_toolchain.sh through its --green-check seam:
-//! one recorded actions/runs shape per branch of the rule. Needs bash and jq on
-//! the host, which the linux CI lane has; elsewhere the suite skips.
+//! The green predicate of roll_toolchain.sh through its --green-check seam - one recorded
+//! actions/runs shape per branch of the rule - and the worktree guard through --dirty-check,
+//! on a scratch repository. Needs bash, jq and git on the host, which the extended-checks
+//! pull-request lane's macos-15 image carries; elsewhere the suite skips.
 
 let SCRIPT = "utils/internal/dasweb-buildd/roll_toolchain.sh"
 
-def private tools_present : bool {
-    if (!stat(SCRIPT).is_valid) {
-        return false
-    }
-    let rc = unsafe(popen_argv(["jq", "--version"], 30.0) $(_f) {
+def private tool_answers(tool : string) : bool {
+    let rc = unsafe(popen_argv([tool, "--version"], 30.0) $(_f) {
     })
     return rc == 0
+}
+
+// The script from the repo root, bash, and the one tool the seam under test spawns.
+def private tools_present(tool : string) : bool {
+    return stat(SCRIPT).is_valid && tool_answers("bash") && tool_answers(tool)
+}
+
+def private git(dir : string; args : array<string>) : int {
+    var argv <- ["git", "-C", dir, "-c", "core.autocrlf=false", "-c", "user.name=t", "-c", "user.email=t@t"]
+    argv |> push_from(args)
+    return unsafe(popen_argv(argv, 30.0) $(_f) {
+    })
+}
+
+// Runs `blk` in a scratch repository whose tracked files, gen.inc and "gen two.inc", are committed
+// with CRLF endings - the shape a build's regenerator then rewrites with LF - and removes it after.
+def private with_crlf_repo(t : T?; blk : block<(dir : string) : void>) {
+    var err = ""
+    let dir = create_temp_directory("buildd_dirty_", err)
+    if (empty(dir)) {
+        t |> failure("no scratch directory: {err}")
+        return
+    }
+    fwrite(path_join(dir, "gen.inc"), "a\r\nb\r\n")
+    fwrite(path_join(dir, "gen two.inc"), "a\r\nb\r\n")
+    var ready = true
+    for (args in [["init", "-q"], ["config", "core.autocrlf", "false"], ["add", "gen.inc", "gen two.inc"], ["commit", "-qm", "gen"]]) {
+        let rc = git(dir, args)
+        if (rc != 0) {
+            t |> failure("git {join(args, " ")} exited {rc} in {dir}")
+            ready = false
+            break
+        }
+    }
+    if (ready) {
+        invoke(blk, dir)
+    }
+    rmdir_rec(dir)
+}
+
+def private dirty_check(dir : string) : int {
+    return unsafe(popen_argv(["bash", SCRIPT, "--dirty-check", dir], 30.0) $(_f) {
+    })
 }
 
 def private green_check(runs_json : string) : int {
@@ -47,7 +88,7 @@ def private all_required : array<string> {
 
 [test]
 def test_green_predicate(t : T?) {
-    if (!tools_present()) {
+    if (!tools_present("jq")) {
         t |> skip("bash + jq not on this host, or not run from the repo root")
         return
     }
@@ -72,5 +113,48 @@ def test_green_predicate(t : T?) {
         items |> push(run_of("Build doc", "skipped"))
         items |> push(run_of("build", "failure", "pull_request"))
         tt |> equal(green_check(runs_of(items)), 0)
+    }
+}
+
+[test]
+def test_dirty_guard(t : T?) {
+    if (!tools_present("git")) {
+        t |> skip("bash + git not on this host, or not run from the repo root")
+        return
+    }
+    t |> run("a tracked file a build rewrote with the other line ending is put back, and the roll goes on") @(tt : T?) {
+        with_crlf_repo(tt) $(dir) {
+            let gen = path_join(dir, "gen.inc")
+            let gen_two = path_join(dir, "gen two.inc")
+            fwrite(gen, "a\nb\n")
+            fwrite(gen_two, "a\nb\n")
+            tt |> equal(dirty_check(dir), 0)
+            tt |> equal(fread(gen), "a\r\nb\r\n")
+            tt |> equal(fread(gen_two), "a\r\nb\r\n", "a path with a space is restored too")
+        }
+    }
+    t |> run("a tracked file whose content changed refuses the roll") @(tt : T?) {
+        with_crlf_repo(tt) $(dir) {
+            fwrite(path_join(dir, "gen.inc"), "a\nc\n")
+            tt |> equal(dirty_check(dir), 12)
+        }
+    }
+    t |> run("a content change in a path with a space refuses the roll") @(tt : T?) {
+        with_crlf_repo(tt) $(dir) {
+            fwrite(path_join(dir, "gen two.inc"), "a\nc\n")
+            tt |> equal(dirty_check(dir), 12)
+        }
+    }
+    t |> run("a staged change refuses the roll") @(tt : T?) {
+        with_crlf_repo(tt) $(dir) {
+            fwrite(path_join(dir, "new.txt"), "z\n")
+            git(dir, ["add", "new.txt"])
+            tt |> equal(dirty_check(dir), 12)
+        }
+    }
+    t |> run("a clean worktree passes") @(tt : T?) {
+        with_crlf_repo(tt) $(dir) {
+            tt |> equal(dirty_check(dir), 0)
+        }
     }
 }


### PR DESCRIPTION
**Behavior change: `daspkg build --wasm` no longer reads `<das_root>/lib` - a tree whose `web/output64/lib` holds archives an earlier stage copied there deletes `web/output64/lib/liblibDasModule*.a` once and reruns the build.**

**Why.** The nightly playground went red on arcanoid, and the fix uncovered two silent faults in the wasm toolchain roll. `build --wasm` staged module archives from `<das_root>/lib`, the desktop build's directory, over the fresh ones the web build pins into `web/output64/lib`; on the build box those were wasm archives from Aug 31, so every roll shipped old module code under a new toolchain id, and the first dasGlfw change after that killed every graphics page at startup with a wasm stack-cookie abort. The roll itself had refused for a week: two generated `.das.inc` committed CRLF were rewritten LF by the host build and the guard read that as a hand edit.

**What changes.**
- `build --wasm` stages the runtime and module archives from the web build's own lib dir alone (`stage_wasm_archives`); the content check stays and now guards a web build dir configured for another target.
- The roll's worktree guard restores a tracked file whose diff is line endings only and still refuses content edits and staged changes; `--dirty-check <worktree>` is its test seam.
- `modules/dasAudio` gains a `REVIEW.das`: a program that requires `live/audio_live` and calls `audio_system_create`, `audio_system_finalize`, or `set_audio_thread_command_stream` directly is a finding. `examples/REVIEW.md` carries the human half: a diff that drops the require says why in the PR body.

**Observable behavior.**
- A roll after a dasGlfw change shipped the old Glfw archive -> it ships the one just built.
- A build-rewritten `.das.inc` blocked the nightly roll with exit 12 -> the roll restores it and proceeds; a real edit still exits 12.
- A live program calling `audio_system_finalize()` beside `require live/audio_live` passed review -> the gate walk reports the line.

**Where to look.** `stage_wasm_archives` in `utils/daspkg/commands.das` and `settle_worktree` in `roll_toolchain.sh`; the gate is `modules/dasAudio/REVIEW.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full preflight not run: the change is confined to daspkg's wasm staging, the roll script, and two new checklists; targeted gates ran (daspkg suite 248/248, the roll test 12/12, the tree-wide REVIEW.das walk, lint and format on the changed files, the make-pr mechanical gates).
- The archive fault was pinned by cross-linking the box's and a Mac's objects and archives one at a time on the same sample: only the box's Glfw archive crashed, and it carried the pre-Sep-10 `dasGLFW.main.cpp`.
- `build --wasm` ran end to end on a Mac tree whose `lib/` holds native archives (the case the old code refused) and staged nine archives.
- zen4 repaired by hand and rolled to cde94e5eb with the fixed script installed; arcanoid, pacman and boulder-dash build and run again in the site's wasm mode.
- Codex round: one finding (unquoted paths in the guard's loop), fixed with a test case that carries a space in the path.

### Claims - stated, not tested
- `cmd_build_wasm` passes `web/output64/lib` to the staging helper: the helper is unit-tested on fixture archives; the call site is covered by the end-to-end run above, not by a test.

### Not done
- One artifact built with the stale archive is still cached on the playground host under toolchain cde94e5eb (the rotating triangle); it needs an `admin.das --op enqueue --force` there or the next toolchain roll.
- A refused roll is still silent outside the box's journal; the nightly playground only goes red once a sample outgrows the stale toolchain.
- The roll's copy of dasImgui's wasm archive list: ledger row 137 in `modules/dasLLAMA/followup_general.md`.

</details>
