### PR TITLE
The records oracle idles 60 s before every timed das cell; ledger rows 138 and 140 carry their verdicts

### DIFF
--- a/modules/dasLLAMA/BRINGUP.md
+++ b/modules/dasLLAMA/BRINGUP.md
@@ -297,7 +297,7 @@ bin/daslang modules/dasLLAMA/performance/gen_bench_records.das -- --workload all
 ### Oracle mode - the tables as a regression tripwire
 
 ```sh
-# per refactor step on this box (das-only, minutes): re-verify the stored metal rows
+# per refactor step on this box (das-only, tens of minutes - a 60 s cool slot per cell): re-verify the stored metal rows
 bin/daslang modules/dasLLAMA/performance/gen_bench_records.das -- --oracle --legs metal
 ```
 
@@ -309,8 +309,9 @@ fail bar as "suspicious - verify"). Exit is nonzero on any FAIL.
 
 - GATE 1 - llama.cpp never re-measures: no ref runs, ref binaries not even required.
 - GATE 2 - one das pass per row, entered after `--oracle-settle` seconds of idle (default 60,
-  every leg): the previous cell's heat outlives the 12 s reclaim settle and a hot GPU or CPU
-  reads a clean cv 20-30% low. The >3% cv warm-retry stays: it REPLACES a bad cold measure.
+  every leg): the previous cell's heat outlives the 12 s reclaim settle and a hot chip reads a
+  clean cv 20-30% low (M5 Max, Metal). The >3% cv warm-retry stays: it REPLACES a bad cold
+  measure.
 - GATE 3 - a timed text cell is frozen: the batch starts with the lifecycle wipe, a prepare
   pass bakes its image, and the timed child runs `lcpp_bench --frozen` (it never converts);
   ASR and image-chat cells bake what they need mid-cell. The store is never written.

--- a/modules/dasLLAMA/BRINGUP.md
+++ b/modules/dasLLAMA/BRINGUP.md
@@ -308,7 +308,9 @@ re-measures ONCE and gates one-sided against its stored mean - drop past `--orac
 fail bar as "suspicious - verify"). Exit is nonzero on any FAIL.
 
 - GATE 1 - llama.cpp never re-measures: no ref runs, ref binaries not even required.
-- GATE 2 - one das pass per row. The >3% cv warm-retry stays: it REPLACES a bad cold measure.
+- GATE 2 - one das pass per row, entered after `--oracle-settle` seconds of idle (default 60,
+  every leg): the previous cell's heat outlives the 12 s reclaim settle and a hot GPU or CPU
+  reads a clean cv 20-30% low. The >3% cv warm-retry stays: it REPLACES a bad cold measure.
 - GATE 3 - a timed text cell is frozen: the batch starts with the lifecycle wipe, a prepare
   pass bakes its image, and the timed child runs `lcpp_bench --frozen` (it never converts);
   ASR and image-chat cells bake what they need mid-cell. The store is never written.

--- a/modules/dasLLAMA/PROFILE.md
+++ b/modules/dasLLAMA/PROFILE.md
@@ -125,6 +125,10 @@ DASLLAMA_BOX=<box> bin/daslang modules/dasLLAMA/performance/gen_bench_records.da
   restored it; llama.cpp refs never moved). The cv retry cannot catch a stable-low cell - only
   cool-slot entry can. Refs get no cool slot on purpose: they are insensitive, and skipping it
   saves hours.
+- `--oracle-settle <seconds>` (default 60) idles before every timed oracle cell, GPU and CPU
+  legs alike. The previous cell's heat outlives the 12 s reclaim settle: on the M5 the GPU
+  still runs a Moderate-pressure 990-1420 MHz instead of 1620 when the next cell starts
+  (tg128 -20%, pp512 -33%, a FAIL and a retry slot spent on a cold read); 60 s reads Nominal.
 
 Then merge the per-box stores into the file the site renders:
 

--- a/modules/dasLLAMA/PROFILE.md
+++ b/modules/dasLLAMA/PROFILE.md
@@ -11,8 +11,9 @@ Three rigs, below, and which one you want depends on the model size:
 Rigs 2 and 3 spawn `benchmarks/lcpp_bench.das` once per cell - that is the only thing that measures
 board performance, and no second harness gets written.
 
-**Reach for rig 1 first.** "Run the oracle" on the big board costs tens of minutes per box; the
-small tier answers the same question - did this change cost performance - in a fraction of it.
+**Reach for rig 1 first.** "Run the oracle" on the big board costs an hour or so per box (a
+60 s cool slot before each of its timed cells alone is most of it); the small tier answers the
+same question - did this change cost performance - in a fraction of it.
 
 ---
 
@@ -126,9 +127,10 @@ DASLLAMA_BOX=<box> bin/daslang modules/dasLLAMA/performance/gen_bench_records.da
   cool-slot entry can. Refs get no cool slot on purpose: they are insensitive, and skipping it
   saves hours.
 - `--oracle-settle <seconds>` (default 60) idles before every timed oracle cell, GPU and CPU
-  legs alike. The previous cell's heat outlives the 12 s reclaim settle: on the M5 the GPU
-  still runs a Moderate-pressure 990-1420 MHz instead of 1620 when the next cell starts
-  (tg128 -20%, pp512 -33%, a FAIL and a retry slot spent on a cold read); 60 s reads Nominal.
+  legs alike. The previous cell's heat outlives the 12 s reclaim settle: on the M5 Max
+  (`powermetrics --samplers gpu_power,thermal` beside the Metal cells) the GPU still runs a
+  Moderate-pressure 990-1420 MHz instead of 1620 when the next cell starts (tg128 -20%, pp512
+  -33%, a FAIL and a retry slot spent on a cold read); 60 s reads Nominal.
 
 Then merge the per-box stores into the file the site renders:
 

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -2,19 +2,19 @@
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
 docs: `ARCHITECTURE.md`, `ARCHITECTURE_ENGINE.md`, `ARCHITECTURE_RUNTIME.md`,
-`ARCHITECTURE_MEASUREMENT.md` (the other companions belong to the routed checklists). Planned
-work: `followup_general.md`, `followup_vulkan.md`, `followup_metal.md` (the Metal tier, and CPU
-work measured on macOS), `PERF_LEDGER.md` (performance goes to the perf ledger, everything else
-to the followup ledgers).
+`ARCHITECTURE_MEASUREMENT.md` (routed checklists own the other companions). Planned work:
+`followup_general.md` (rig and instrument rows included), `followup_vulkan.md` (engine work on
+the Vulkan tier), `followup_metal.md` (engine work on the Metal tier, or CPU engine work
+measured on macOS), `PERF_LEDGER.md` (performance; the rest goes to the followup ledgers).
 
 **A dasLLAMA `[test]` file, wherever the diff puts it, answers to this module's
 `tests/REVIEW.md`.**
 
-**A timing rig (a file that times a run and reports a wall-clock time or rate as its result,
-printed or returned to a caller that prints it), a kernel race (a run that times two kernel
-variants - arms - against each other in one process), or a function a
-`benchmarks/lcpp_bench.das` cell's timed body calls, wherever it lives, answers to this
-folder's `benchmarks/REVIEW.md` in addition to its own folder's checklist.**
+**A timing rig (a file that times a run itself and reports a wall-clock time or rate as its
+result, printed or returned to a caller that prints it - a driver reading a child's clock is
+not one), a kernel race (a run timing two kernel variants - arms - against each other in one
+process), or a function a `benchmarks/lcpp_bench.das` cell's timed body calls, wherever it
+lives, answers to this folder's `benchmarks/REVIEW.md` beside its own folder's checklist.**
 
 **A diff that writes a measured number down - into `PERF_LEDGER.md`, a checked-in doc, a
 code comment, checked-in data a run produced, or a PR body - or adds a serving path or moves
@@ -178,11 +178,11 @@ template strings any of them look up, records a run of this folder's
 An override is an environment knob, an exported runtime setter, or an on-disk state file - one
 a run writes or a user places, never data a build ships - that moves a gate, policy, or
 threshold off its default and so changes what the run writes, reads, mints, or computes (a
-timing knob included when it moves numerics); a knob that changes only WHEN work happens is not
-one, and a CLI flag never is. The announce is a line printed where the override changes the
-outcome, naming it by the spelling a user would set (the env variable, the sidecar or file key,
-the setter's name) and, for one that is on unless turned off, the spelling that turns it off;
-one with no off spelling says so. Per-site repeats are fine; a set-but-inert override is silent.
+timing knob is one only when it moves a number other than a measured time); a CLI flag never
+is one. The announce is a line printed where the override changes the outcome, naming it by
+the spelling a user would set (the env variable, the sidecar or file key, the setter's name)
+and, for one that is on unless turned off, the spelling that turns it off; one with no off
+spelling says so. Per-site repeats are fine; a set-but-inert override is silent.
 
 **A tutorial source, `.rst` page, docstring, help string, `README.md`, or checked-in document
 outside this folder left showing the old call, flag, or default after a change to user-facing API
@@ -204,10 +204,10 @@ without both halves of the pair that makes it an entry module - the `ARCHITECTUR
 sec.1.8 charter line naming it a sanctioned public entry point, and the DASLLAMA001 error text
 naming it beside the facade. The allowed set is the table in the lint.
 
-**A `// nolint:STYLE037` or `// nolint:STYLE038` on a function a follow-up ledger entry says
-can be shortened or split is a defect - land the ledgered split instead.** The warning is what
-keeps the ledger entry visible. A ledger entry asking for a dedup across bodies - one template
-for several twins - does not fire this rule: the one body left still carries its length.
+**A STYLE037 or STYLE038 suppression, `// nolint:` or the file's `options _function_length` /
+`_cyclomatic_complexity`, on a function a follow-up ledger entry says can be shortened or split
+is a defect - land the ledgered split instead.** The warning keeps the entry visible; an entry
+asking that twin bodies merge into one template does not fire this rule.
 
 **`options _dasllama_internal` belongs only in a file whose job is to reach engine
 internals: an engine file under `dasllama/`, a test, harness, benchmark, or rig this module

--- a/modules/dasLLAMA/REVIEW_MEASUREMENT.md
+++ b/modules/dasLLAMA/REVIEW_MEASUREMENT.md
@@ -13,7 +13,7 @@ provenance line covers it.
 **A `PERF_LEDGER.md` entry states a served-turn figure of the engine this repository builds - a
 tok/s rate or a turn wall - only when the released `lcpp_bench` exe (`benchmarks/lcpp_bench.das`
 built by `daspkg release`) or a board cell produced it.** A served turn is one whole request an
-engine serves - a prefill-plus-decode run, or one synthesis; a turn wall is its wall.
+engine serves, whatever the modality; a turn wall is its wall.
 
 **A `-jit` A/B pair enters `PERF_LEDGER.md` as its ratio, with the arms' absolute rates left in
 the run's report.** The `-jit` script is `benchmarks/lcpp_bench.das` run as a script under
@@ -32,9 +32,10 @@ one side of a pair held against the other - a knob value, a kernel form, a build
 **A diff that adds a `PERF_LEDGER.md` entry whose reading no board cell produced names the
 instrument that produced it - the script or exe whose output is that wall or rate.** A board
 cell is a run `performance/gen_bench_records.das` spawns, or a manual
-`benchmarks/lcpp_bench.das` cell its `PROFILE.md` section documents; its reading lands as a row
-of `performance/records/<box>.json`. A ruler record (`performance/records/mtp/*.json`, written
-by `harness/mtp_ruler.das`) is not a board cell.
+`benchmarks/lcpp_bench.das` cell its `PROFILE.md` section documents, whose reading lands as a
+row of `performance/records/<box>.json`; an `--oracle` re-measure is not one - it never writes
+the store. A ruler record (`performance/records/mtp/*.json`, written by
+`harness/mtp_ruler.das`) is not a board cell.
 
 **A ruler record's third-party row is written by the same `harness/mtp_ruler.das` run that
 wrote the das row it pairs with.** A wall pasted in from another run measures a different
@@ -79,17 +80,15 @@ the same change, and names that row in the PR body.** A box mints a path when
 the module's committed record of what serving costs; a kernel win that never lands there is
 invisible to the next regression check.
 
-**A timing figure of a served turn as a whole - tok/s, latency, a whole-turn model or engine
-comparison, the 512-token prefill (pp512) and 128-token decode (tg128) rates, a synthesis's
-real-time factor (RTF) - written down as a measurement rather than as a prediction - is a
-defect without either a board cell behind it or a provenance line naming harness, flags,
-environment overrides, box, and the exe or script that ran it.** Flags are the tier (`-jit` or
-not), the `DAS_TUNE_POLICY` value in force, and the kernel backend the run served on. The board
-cell states its quant mode and stamps box and engine provenance, so a number can never silently
-describe a format nobody serves or a kernel set nobody ships.
+**A rate or wall of any leg of a served turn - prefill, decode, or the turn end to end -
+written down as a measurement rather than as a prediction, is a defect without either a board
+cell behind it or a provenance line naming harness, flags, environment overrides, box, and the
+exe or script that ran it.** Flags are the tier (`-jit` or not), the `DAS_TUNE_POLICY` value in
+force, and the kernel backend the run served on.
 
-**A figure that covers less than one whole served turn and whose value depends on the box it
-ran on - timing or not - names the harness, the flags and the box that produced it.** A figure
+**A figure below a leg of a served turn - a kernel, a layer, an op, a clock or a residency -
+whose value depends on the box it ran on names the harness, the flags and the box that
+produced it.** A figure
 a committed board cell or ruler record produced names the record and row instead.
 
 **A figure whose value is the same on every box names the build, fixture, or command that
@@ -101,9 +100,10 @@ model, never spawning a child process.** A shipped exe carries no vehicle model 
 file a harness run drives - and no harness script, so a model or a child there is a hang or a
 silent skip.
 
-**A shipped exe's startup race never races a `[tune]` kernel family; a GPU pso twin race, which
-only sets a runtime knob, is what a first start may do** (`ARCHITECTURE_MEASUREMENT.md`
-sec.2.42a). A `[tune]` winner needs a recompiled clone the shipped exe does not carry.
+**A shipped exe's startup race never races a `[tune]` kernel family; a GPU pipeline-state twin
+race, which only sets a runtime knob, is what a first start may do**
+(`ARCHITECTURE_MEASUREMENT.md` sec.2.42a). A `[tune]` winner needs a recompiled clone the
+shipped exe does not carry.
 
 **A diff never adds a confirm - an end-to-end A/B served on a vehicle model in a spawned
 child - outside `harness/`.**

--- a/modules/dasLLAMA/followup_general.md
+++ b/modules/dasLLAMA/followup_general.md
@@ -1543,16 +1543,19 @@
     below its stored mean (gemma-4-12B tg128 -28% / pp512 -43%, gemma-4-26B tg128 -19%,
     Qwen3.8-27B tg128 -41%, and on a second board gemma-4-E4B tg128 -21%, Qwen3.6-27B pp512
     -32%, Qwen3.6-35B-A3B pp512 -33% / tg128 -20%), and the solo re-run after the 180 s settle
-    lands within 1% every time. Reproduced on the M5 box with the board's own sequence - a big
-    model's timed cell, then the victim's prepare, the 12 s settle, the victim's timed cell - five
-    of five times: the GPU enters Moderate thermal pressure during the big cell and runs the
-    victim at 990-1420 MHz instead of 1620 (Qwen3.6-35B pp512 2444 +- 628, tg128 103 vs 3401 /
-    127.5), while the page-in counter, the residency rails and the map's reclaim state show
-    nothing; a 60 s settle reads Nominal and lands within 1%, a 120 s settle the same. The
-    prepare is only the sequence's shape: the throttle is the previous cell's heat, and the 12 s
-    `--settle` is a reclaim window, not a cooling one, so the oracle idles `--oracle-settle`
-    seconds (60) before every timed cell, on every leg - the Vulkan boxes show the same cold
-    first read. Unquirked: a timed cell waits for the process's thermal state to read nominal
+    lands within 1% every time. Reproduced on the M5 Max box with the board's own sequence - a
+    big model's timed cell, then the victim's prepare, the 12 s settle, the victim's timed cell
+    - five of five times, the cells run by hand as the oracle runs them (the released
+    `dasllama-bench` exe, `--frozen`, the box's tuned sidecar, no overrides) with
+    `powermetrics --samplers gpu_power,thermal` reading the GPU clock and the pressure level:
+    the GPU enters Moderate thermal pressure during the big cell and runs the victim at
+    990-1420 MHz instead of 1620 (Qwen3.6-35B pp512 2444 +- 628, tg128 103 vs 3401 / 127.5),
+    while the page-in counter, the residency rails and the map's reclaim state show nothing; a
+    60 s settle reads Nominal and lands within 1%, a 120 s settle the same. The prepare is only
+    the sequence's shape: the throttle is the previous cell's heat, and the 12 s `--settle` is a
+    reclaim window, not a cooling one, so the oracle idles `--oracle-settle` seconds (60) before
+    every timed cell, on every leg - the Vulkan boards report the same first-read drop, not yet
+    instrumented. Unquirked: a timed cell waits for the process's thermal state to read nominal
     (`NSProcessInfo.thermalState`, no sudo) with a capped wait, so the box's own reading
     replaces a fixed number that is too long for a cool box and may be too short for a hot one.
 139. **The tuner's end-to-end confirm reads a stamp line a warm JIT does not print.** The
@@ -1577,10 +1580,13 @@
     between the August 30 record and master's head, not in a branch. The short-clip bias (a
     larger loss the shorter the clip) points at per-call overhead - a wake, a prep, or a
     kernel winner that lost its small-shape arm - rather than a GEMM's steady-state rate.
-    Replicated on the M5 box after a reboot with a worktree at the recording commit (013a151f4)
-    beside master's head, the parakeet jfk.wav cell interleaved, eight reps a run, five runs a
-    tree: best reps equal (146 vs 143 ms), medians 158.5 vs 162.5 (2.5%). An 11% step would show
-    in one run of eight; none did. The spread is placement: the box's six Super cores stay
+    Replicated on the M5 Max box after a reboot with a worktree at the recording commit
+    (013a151f4) beside master's head, the parakeet jfk.wav cell interleaved, eight reps a run,
+    five runs a tree, each tree's own `-jit` binary on a single-clip script in the bench's
+    regime (its jobque, five workers, the box profile, `DASLLAMA_ALLOW_UNTUNED=1
+    DAS_TUNE_MANIFEST=0`), the cluster residency read by `powermetrics --samplers cpu_power`:
+    best reps equal (146 vs 143 ms), medians 158.5 vs 162.5 (2.5%). An 11% step would show in
+    one run of eight; none did. The spread is placement: the box's six Super cores stay
     saturated while the twelve Performance cores take 35% of the run when fast and 55% when
     slow, per rep, on both trees and both affinity modes. The oracle's shortfall is a record
     minted as a best-of-two on a fresh box read against a placement-scattered box; the residual

--- a/modules/dasLLAMA/followup_general.md
+++ b/modules/dasLLAMA/followup_general.md
@@ -1541,23 +1541,19 @@
 138. **The records oracle's first read after an image prepare is cold.** In `--oracle --legs
     metal` the first measure of a text cell whose image the batch just mapped or baked reads far
     below its stored mean (gemma-4-12B tg128 -28% / pp512 -43%, gemma-4-26B tg128 -19%,
-    Qwen3.8-27B tg128 -41%), and the solo re-run after the 180 s settle lands within 1% every
-    time; cells whose prepare found a warm image read flat first time. The prepare pass and the
-    timed child are separate processes, so the suspect is residual state the prepare leaves
-    behind - a mapping still reclaiming asynchronously, the previous cell's GPU residency, or the
-    page cache not yet holding the fresh image - not the code under test; the residency thread
-    that keeps Metal buffers pinned across submissions is the second suspect (the prepare pass
-    ran it, the timed child starts one of its own against the same image). A second board on the
-    same box reads cold on different cells (gemma-4-E4B tg128 -21%, Qwen3.6-27B pp512 -32% /
-    tg128 -13%, Qwen3.6-35B-A3B pp512 -33% / tg128 -20%, each retry within 2%) - the pp512
-    shortfall is bandwidth, so the pages not being resident is the leading reading. The
-    experiments that split the suspects, cheapest first: one failing cell with `--settle 60`
-    (OS reclaim of the prepare child's map), the same cell under `DASLLAMA_METAL_RESIDENCY=0`
-    and `DASLLAMA_METAL_HEARTBEAT_S=0` (the residency thread), the cell JSON's five reps (a slow
-    rep 1 is page-in warmup, five slow reps is the box), `vm_stat` / `powermetrics` sampled
-    between prepare exit and cell start, and the LENS for per-dispatch timing. Unquirked: the
-    oracle reads a prepared cell's residual state before timing (or takes the warm-retry as the
-    first measure by design), so a cold first read never spends a FAIL and a retry slot.
+    Qwen3.8-27B tg128 -41%, and on a second board gemma-4-E4B tg128 -21%, Qwen3.6-27B pp512
+    -32%, Qwen3.6-35B-A3B pp512 -33% / tg128 -20%), and the solo re-run after the 180 s settle
+    lands within 1% every time. Reproduced on the M5 box with the board's own sequence - a big
+    model's timed cell, then the victim's prepare, the 12 s settle, the victim's timed cell - five
+    of five times: the GPU enters Moderate thermal pressure during the big cell and runs the
+    victim at 990-1420 MHz instead of 1620 (Qwen3.6-35B pp512 2444 +- 628, tg128 103 vs 3401 /
+    127.5), while the page-in counter, the residency rails and the map's reclaim state show
+    nothing; a 60 s settle reads Nominal and lands within 1%, a 120 s settle the same. The
+    prepare is only the sequence's shape: the throttle is the previous cell's heat, and the 12 s
+    `--settle` is a reclaim window, not a cooling one. Unquirked: a timed cell waits for the
+    process's thermal state to read nominal (`NSProcessInfo.thermalState`, no sudo) with a
+    capped wait, or the settle before a das cell rises to the 60 s the box needs - either way a
+    cold first read never spends a FAIL and a retry slot.
 139. **The tuner's end-to-end confirm reads a stamp line a warm JIT does not print.** The
     generator confirm (`gen_tune_probe.das`, confirm_e2e_prefill) scores each arm by the
     `llvm_tune: q8q8_tile_gen <- <perm>` line of a verbose child, and a child that runs the

--- a/modules/dasLLAMA/followup_general.md
+++ b/modules/dasLLAMA/followup_general.md
@@ -1550,10 +1550,11 @@
     127.5), while the page-in counter, the residency rails and the map's reclaim state show
     nothing; a 60 s settle reads Nominal and lands within 1%, a 120 s settle the same. The
     prepare is only the sequence's shape: the throttle is the previous cell's heat, and the 12 s
-    `--settle` is a reclaim window, not a cooling one. Unquirked: a timed cell waits for the
-    process's thermal state to read nominal (`NSProcessInfo.thermalState`, no sudo) with a
-    capped wait, or the settle before a das cell rises to the 60 s the box needs - either way a
-    cold first read never spends a FAIL and a retry slot.
+    `--settle` is a reclaim window, not a cooling one, so the oracle idles `--oracle-settle`
+    seconds (60) before every timed cell, on every leg - the Vulkan boxes show the same cold
+    first read. Unquirked: a timed cell waits for the process's thermal state to read nominal
+    (`NSProcessInfo.thermalState`, no sudo) with a capped wait, so the box's own reading
+    replaces a fixed number that is too long for a cool box and may be too short for a hot one.
 139. **The tuner's end-to-end confirm reads a stamp line a warm JIT does not print.** The
     generator confirm (`gen_tune_probe.das`, confirm_e2e_prefill) scores each arm by the
     `llvm_tune: q8q8_tile_gen <- <perm>` line of a verbose child, and a child that runs the

--- a/modules/dasLLAMA/followup_general.md
+++ b/modules/dasLLAMA/followup_general.md
@@ -1580,10 +1580,16 @@
     between the August 30 record and master's head, not in a branch. The short-clip bias (a
     larger loss the shorter the clip) points at per-call overhead - a wake, a prep, or a
     kernel winner that lost its small-shape arm - rather than a GEMM's steady-state rate.
-    Unquirked: first replicate the August 30 numbers - a worktree at the recording commit
-    (013a151f4) beside master's head, the same cell on both, side by side on a quiet box - then
-    bisect the CPU ASR cell (parakeet jfk.wav, 11 s) across the merges between them under one
-    manifest, and re-record the board.
+    Replicated on the M5 box after a reboot with a worktree at the recording commit (013a151f4)
+    beside master's head, the parakeet jfk.wav cell interleaved, eight reps a run, five runs a
+    tree: best reps equal (146 vs 143 ms), medians 158.5 vs 162.5 (2.5%). An 11% step would show
+    in one run of eight; none did. The spread is placement: the box's six Super cores stay
+    saturated while the twelve Performance cores take 35% of the run when fast and 55% when
+    slow, per rep, on both trees and both affinity modes. The oracle's shortfall is a record
+    minted as a best-of-two on a fresh box read against a placement-scattered box; the residual
+    2.5% between the two commits sits inside that scatter and no bisect resolves it. Unquirked:
+    the oracle's CPU rows carry a placement-aware instrument (the median of many reps, the
+    Performance-cluster residency beside it) before any CPU row is re-recorded or gated.
 141. **Four tower sites release a pool buffer under a byte count that is not its acquire's.** In
     `dasllama_metal_tower.das` the K panel `bk` is acquired at `bytes_rowk` (the 64-padded key
     rows) and released at `bytes_row` / `bytes_rowp` (the 32-padded rows) at four self-attention

--- a/modules/dasLLAMA/performance/REVIEW.md
+++ b/modules/dasLLAMA/performance/REVIEW.md
@@ -32,14 +32,15 @@ name, in the same change.** The archive is content-addressed; a row left on the 
 points at a file that no longer exists.
 
 **A diff that writes a reference-engine row - a run row whose `engine` is not `das` - to
-`records/` whose `sha` names anything but the standing ref pin (`DEFAULT_REF_SHA`,
+`records/<box>.json` whose `sha` names anything but the standing ref pin (`DEFAULT_REF_SHA`,
 `../benchmarks/setup_lcpp_ref.das`) is a defect - re-mint.**
 
-**A reference-engine row that carries no `sha` names, in its provenance, the checkout that
-built the binary it timed; a python leg names `../benchmarks/asr/requirements-*.txt` instead.**
+**A diff that writes a reference-engine row carrying no `sha` to `records/<box>.json` names,
+in that row's provenance, the checkout that built the binary it timed; a python leg names
+`../benchmarks/asr/requirements-*.txt` instead.**
 
-**A diff that writes a records row, sidecar archive, or `defaults/` profile under this
-folder whose version pin is missing, or differs from `DASLLAMA_RELEASE`
+**A diff that writes a `records/<box>.json` row, sidecar archive, or `defaults/` profile under
+this folder whose version pin is missing, or differs from `DASLLAMA_RELEASE`
 (`../dasllama/dasllama_version.das`), is a defect - re-mint.** The pin is a records row's
 `dasllama_version`, and `provenance.dasllama_version` in a sidecar archive or a `defaults/`
 profile. For a sidecar with an `engine_sha`, read the value at that commit; a `defaults/`
@@ -59,17 +60,16 @@ diff that adds one names the ruler command line in the PR body.** The ruler reco
 speculative round's cell (`../ARCHITECTURE_MEASUREMENT.md` sec.2.45); its shape is the ruler's,
 and the board walkers (`list_record_stores`) do not read it.
 
-**A `records/mtp/` file names its engines in `meta.das_sha`, and in `meta.lcpp_version` when
-a reference arm ran (`-` when none did).**
+**A diff that adds or changes a `records/mtp/` file names its engines in `meta.das_sha`, and in
+`meta.lcpp_version` when a reference arm ran (`-` when none did).**
 
-**A `records/mtp/` file that carries a reference-engine row with no `das` row from the same run
-is a defect - re-mint the pair.**
+**A diff that adds or changes a `records/mtp/` file carrying a reference-engine row with no
+`das` row from the same run is a defect - re-mint the pair.**
 
-**A `records/mtp/` file whose `meta.settle` is below the ruler's default names the reason in
-the PR body.**
-
-**A diff that adds a `records/mtp/` file whose `meta.settle` is below the ruler's default names
-its rows `direction-grade` wherever it cites them.**
+**A diff that adds or changes a `records/mtp/` file whose `meta.settle` is missing, or below
+the ruler's `--settle` default (the ruler's `--help` states it), names the reason in the PR body
+and labels the file's rows `direction-grade` everywhere the change cites them - PR body, ledger
+rows, architecture or profile docs.**
 
 **A diff that writes a `das` row - a run row whose `engine` is `das` - to `records/<box>.json`
 times that row with the released `lcpp_bench` exe.** That exe is
@@ -91,8 +91,8 @@ second tool's record carrying the wrong engine, and looks real.
 board membership, provenance, or parity fixtures is a defect - write it as a view over those
 two functions.** Board membership is which models the site results board shows.
 
-**A view over `model_specs()` or `asr_catalog()` recomputes from them on every call and stores
-no `url`, `bytes`, or `sha256` of its own.**
+**A diff that adds or changes a view over `model_specs()` or `asr_catalog()` recomputes from
+them on every call; a view storing a `url`, `bytes`, or `sha256` of its own is a defect.**
 
 **A view over `model_specs()` or `asr_catalog()` selects its rows by one field whose value on
 the row states membership; a view that matches a field against a list of literal values - file

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -111,6 +111,10 @@ struct Args {
     @clarg_doc = "Oracle: seconds to idle before the automatic solo re-run of a FAILED cell, whose verdict then stands (default: 180; 0 disables) — board-tail cells under-read on a hot chip (−6.5%..−34% observed; thermal recovery takes ~3 min), a solo re-run after settle reads true"
     oracle_retry_settle : int = 180
 
+    @clarg_name = "oracle-settle"
+    @clarg_doc = "Oracle: seconds to idle before each timed das cell (default: 60) — the previous cell's heat throttles the GPU through a 12 s reclaim settle (M5: 990-1420 MHz vs 1620, tg128 −20%, pp512 −33%); 60 s reads Nominal on every leg, GPU and CPU alike"
+    oracle_settle : int = 60
+
     @clarg_name = "oracle-allow-crossgen"
     @clarg_doc = "Oracle: compare across sidecar generations anyway (default: a tune_sha mismatch is INCOMPARABLE — the stored mean belongs to different winners — and fails the run)"
     oracle_allow_crossgen : bool
@@ -321,17 +325,11 @@ def private stamp_note(var models : array<BenchModel>; gguf, note : string) {
     }
 }
 
-// idle gap before every pass — lets the kernel finish reclaiming the previous child's map
-def private settle(cfg : Args) {
-    if (cfg.settle > 0) {
-        sleep(uint(cfg.settle * 1000))
-    }
-}
-
-// cool-slot entry for das cells: thermal recovery, not map-reclaim churn — see --das-settle
-def private settle_das(cfg : Args) {
-    if (cfg.das_settle > 0) {
-        sleep(uint(cfg.das_settle * 1000))
+//! idle gap before a pass: --settle reclaims the previous child's map, --das-settle and
+//! --oracle-settle cool the chip; 0 skips the gap
+def private settle(seconds : int) {
+    if (seconds > 0) {
+        sleep(uint(seconds * 1000))
     }
 }
 
@@ -387,7 +385,7 @@ def private run_das_child(file, path, be, tag, exe : string; accel, frozen : boo
         if (attempt == 0) {
             to_log(LOG_WARNING, "gen_bench_records: HIGH VARIANCE {file} das {tag} (cv {worst * 100.0lf:.1f}%) - cold-map warming suspect, re-running the cell warm\n")
             logger_warning("bench.records", "high variance - warm re-run", JV({"model" => JV(file), "leg" => JV(tag), "cv_pct" => JV(worst * 100.0lf)}))
-            settle(cfg)
+            settle(cfg.settle)
         } else {
             to_log(LOG_WARNING, "gen_bench_records: STILL HIGH VARIANCE {file} das {tag} (cv {worst * 100.0lf:.1f}%) after a warm re-run - keeping it, treat with suspicion\n")
         }
@@ -674,14 +672,14 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                 if (!crossgen_ok(sr, currentSha, cfg.oracle_allow_crossgen, "{m.gguf} das image", board, fails, warns)) {
                     continue
                 }
-                settle(cfg)
+                settle(cfg.oracle_settle)
                 let pic = "{models_dir()}{bench_image_fixture()}"
                 var vi = oracle_image_cell(m.gguf, mm, pic, sr, imgLeg, cfg, threads, cellPath, exe, board)
                 if (vi == OracleVerdict.fail && cfg.oracle_retry_settle > 0) {
                     // same contract as the LLM legs below: the solo re-run's verdict stands
                     to_log(LOG_WARNING, "gen_bench_records: ORACLE FAIL {m.gguf} - auto solo re-run after {cfg.oracle_retry_settle}s settle (the retry is the verdict)\n")
                     board |> push("  ^ suspect FAIL - the auto solo re-run below is the verdict")
-                    sleep(uint(cfg.oracle_retry_settle * 1000))
+                    settle(cfg.oracle_retry_settle)
                     vi = oracle_image_cell(m.gguf, mm, pic, sr, imgLeg, cfg, threads, cellPath, exe, board)
                 }
                 if (vi == OracleVerdict.fail) {
@@ -724,13 +722,13 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                 if (!crossgen_ok(sr, currentSha, cfg.oracle_allow_crossgen, "{m.gguf} das asr", board, fails, warns)) {
                     continue
                 }
-                settle(cfg)
+                settle(cfg.oracle_settle)
                 var va = oracle_asr_cell(spec, sr, asrLeg, cfg, threads, cellPath, exe, board)
                 if (va == OracleVerdict.fail && cfg.oracle_retry_settle > 0) {
                     // same contract as the LLM legs below: the solo re-run's verdict stands
                     to_log(LOG_WARNING, "gen_bench_records: ORACLE FAIL {m.gguf} - auto solo re-run after {cfg.oracle_retry_settle}s settle (the retry is the verdict)\n")
                     board |> push("  ^ suspect FAIL - the auto solo re-run below is the verdict")
-                    sleep(uint(cfg.oracle_retry_settle * 1000))
+                    settle(cfg.oracle_retry_settle)
                     va = oracle_asr_cell(spec, sr, asrLeg, cfg, threads, cellPath, exe, board)
                 }
                 if (va == OracleVerdict.fail) {
@@ -776,14 +774,14 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                 continue
             }
             oracle_prepare(m.gguf, be, tag, exe, accel, threads, cellPath)
-            settle(cfg)
+            settle(cfg.oracle_settle)
             var v = oracle_cell(m.gguf, be, tag, exe, accel, sr, cfg, threads, cellPath, board)
             if (v == OracleVerdict.fail && cfg.oracle_retry_settle > 0) {
                 // a tail-of-board FAIL is a re-run instruction, never a verdict (BRINGUP): the
                 // solo re-run after settle is automatic, and ITS verdict stands
                 to_log(LOG_WARNING, "gen_bench_records: ORACLE FAIL {m.gguf} - auto solo re-run after {cfg.oracle_retry_settle}s settle (the retry is the verdict)\n")
                 board |> push("  ^ suspect FAIL - the auto solo re-run below is the verdict")
-                sleep(uint(cfg.oracle_retry_settle * 1000))
+                settle(cfg.oracle_retry_settle)
                 v = oracle_cell(m.gguf, be, tag, exe, accel, sr, cfg, threads, cellPath, board)
             }
             if (v == OracleVerdict.fail) {
@@ -1428,27 +1426,27 @@ def main : int {
         // state (27B: das 110.7 soaked vs 138.1 quiet — a phantom 0.91 board red). Refs still
         // run independently of das-cell failures.
         if (doLlm && legMetal) {
-            settle_das(cfg)
+            settle(cfg.das_settle)
             das_cell(file, path, "metal", exe, false, cfg, threads, cellPath, ent.note, store, models, failed)
             // the ref gets COOL-SLOT entry too: it is not insensitive on high-power parts —
             // zen2 35B read pp 81.7 twelve seconds behind a das cell vs 103.9 solo-cooled
-            settle_das(cfg)
+            settle(cfg.das_settle)
             ref_pass(file, path, refStock, "stock", 99, false, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
         }
         if (doLlm && legNeon) {
-            settle_das(cfg)
+            settle(cfg.das_settle)
             das_cell(file, path, "cpu", exe, false, cfg, threads, cellPath, ent.note, store, models, failed)
             // the ref gets COOL-SLOT entry too: it is not insensitive on high-power parts —
             // zen2 35B read pp 81.7 twelve seconds behind a das cell vs 103.9 solo-cooled
-            settle_das(cfg)
+            settle(cfg.das_settle)
             ref_pass(file, path, refClean, "clean-cpu", 0, false, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
         }
         if (doLlm && legAmx) {
-            settle_das(cfg)
+            settle(cfg.das_settle)
             das_cell(file, path, "cpu", exe, true, cfg, threads, cellPath, ent.note, store, models, failed)
             // the ref gets COOL-SLOT entry too: it is not insensitive on high-power parts —
             // zen2 35B read pp 81.7 twelve seconds behind a das cell vs 103.9 solo-cooled
-            settle_das(cfg)
+            settle(cfg.das_settle)
             ref_pass(file, path, refStock, "stock", 0, true, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
         }
         // the image-chat legs of a vision decoder (an mmproj companion) — same
@@ -1461,22 +1459,22 @@ def main : int {
             // CPU build (kernel vs kernel — stock ggml op-offloads to Metal even at -ngl 0);
             // amx vs stock -ngl 0 --no-op-offload
             if (legMetal) {
-                settle_das(cfg)
+                settle(cfg.das_settle)
                 image_das_cell(file, path, mmPath, picPath, cfg, threads, cellPath, ent.note, store, exe, models, failed, "metal")
-                settle_das(cfg)
+                settle(cfg.das_settle)
                 image_ref_pass(file, path, mmPath, picPath, stockMtmd, "stock", 99, false, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
             }
             if (legNeon) {
-                settle_das(cfg)
+                settle(cfg.das_settle)
                 image_das_cell(file, path, mmPath, picPath, cfg, threads, cellPath, ent.note, store, exe, models, failed)
-                settle_das(cfg)
+                settle(cfg.das_settle)
                 let cpuMtmd = mtmd_bin()
                 image_ref_pass(file, path, mmPath, picPath, stat(cpuMtmd).is_valid ? cpuMtmd : "", "clean-cpu", 0, false, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
             }
             if (legAmx) {
-                settle_das(cfg)
+                settle(cfg.das_settle)
                 image_das_cell(file, path, mmPath, picPath, cfg, threads, cellPath, ent.note, store, exe, models, failed, "accel")
-                settle_das(cfg)
+                settle(cfg.das_settle)
                 image_ref_pass(file, path, mmPath, picPath, stockMtmd, "stock", 0, true, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
             }
         }
@@ -1507,15 +1505,15 @@ def main : int {
                 to_log(LOG_INFO, "gen_bench_records: SKIP {spec.display} - not in --asr-tier {cfg.asr_tier}\n")
                 continue
             }
-            settle_das(cfg)
+            settle(cfg.das_settle)
             asr_das_cell(spec, cfg, threads, cellPath, store, exe, models, failed)
             static_if (typeinfo builtin_module_exists(das_accelerate)) {
-                settle_das(cfg)
+                settle(cfg.das_settle)
                 asr_das_cell(spec, cfg, threads, cellPath, store, exe, models, failed, "accel")
             }
             static_if (typeinfo builtin_module_exists(das_metal)) {
                 if (is_metal_served_family(spec)) {   // GPU-served families only: the anti-sandbag would refuse the rest
-                    settle_das(cfg)
+                    settle(cfg.das_settle)
                     asr_das_cell(spec, cfg, threads, cellPath, store, exe, models, failed, "metal")
                 }
             }
@@ -1523,11 +1521,11 @@ def main : int {
                 if (!key_exists(toolVersions, rf.tool)) {
                     toolVersions |> insert(rf.tool, asr_ref_available(rf.tool) ? asr_tool_versions(rf.tool) : "")
                 }
-                settle(cfg)
+                settle(cfg.settle)
                 asr_ref_pass(spec, rf, toolVersions?[rf.tool] ?? "", cfg, threads, hw, box, date, store, models, failed)
                 static_if (typeinfo builtin_module_exists(das_metal)) {
                     if (asr_gpu_pair_tool(rf.tool) && is_metal_served_family(spec)) {
-                        settle(cfg)
+                        settle(cfg.settle)
                         asr_ref_pass(spec, rf, toolVersions?[rf.tool] ?? "", cfg, threads, hw, box, date, store, models, failed, true)
                     }
                 }

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -112,7 +112,7 @@ struct Args {
     oracle_retry_settle : int = 180
 
     @clarg_name = "oracle-settle"
-    @clarg_doc = "Oracle: seconds to idle before each timed das cell (default: 60) — the previous cell's heat throttles the GPU through a 12 s reclaim settle (M5: 990-1420 MHz vs 1620, tg128 −20%, pp512 −33%); 60 s reads Nominal on every leg, GPU and CPU alike"
+    @clarg_doc = "Oracle: seconds to idle before each timed das cell, every leg (default: 60) — the previous cell's heat throttles the GPU through a 12 s reclaim settle (M5 Max Metal: 990-1420 MHz vs 1620, tg128 −20%, pp512 −33%); 60 s reads Nominal there"
     oracle_settle : int = 60
 
     @clarg_name = "oracle-allow-crossgen"

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -325,11 +325,11 @@ def private stamp_note(var models : array<BenchModel>; gguf, note : string) {
     }
 }
 
-//! idle gap before a pass: --settle reclaims the previous child's map, --das-settle and
-//! --oracle-settle cool the chip; 0 skips the gap
+// idle gap before a pass: --settle reclaims the previous child's map, --das-settle and
+// --oracle-settle cool the chip; 0 skips the gap
 def private settle(seconds : int) {
     if (seconds > 0) {
-        sleep(uint(seconds * 1000))
+        sleep(uint(seconds) * 1000u)
     }
 }
 

--- a/tests/lsp/test_lsp_protocol.das
+++ b/tests/lsp/test_lsp_protocol.das
@@ -336,8 +336,9 @@ def test_lsp_protocol(t : T?) {   // nolint:STYLE038 one ordered LSP session on 
                 t |> equal(diagnostics_of(pub2), 0)
 
                 // an edit kills the compile in flight for its file: broken, then clean again
-                // once the broken compile has started - the next publish is the clean one, the
-                // stale buffer's never lands
+                // once the broken compile has started. A broken publish may land before the
+                // clean edit is received (the compile can finish inside the gap on a fast box);
+                // the clean publish lands, and nothing stale lands after it
                 write_frame(w, sprint_json(DidChangeMsg(params <- DidChangeParams(
                     textDocument = VersionedDoc(uri = uri, version = 3),
                     contentChanges <- [ContentChange(text = broken)])), false))
@@ -345,16 +346,32 @@ def test_lsp_protocol(t : T?) {   // nolint:STYLE038 one ordered LSP session on 
                 write_frame(w, sprint_json(DidChangeMsg(params <- DidChangeParams(
                     textDocument = VersionedDoc(uri = uri, version = 4),
                     contentChanges <- [ContentChange(text = clean)])), false))
-                let pub3 = read_until(r) $(js) => (js?["method"] ?? "") == "textDocument/publishDiagnostics"
+                var early = 0
+                let pub3 = read_until(r) $(js) {
+                    return false if ((js?["method"] ?? "") != "textDocument/publishDiagnostics")
+                    if (diagnostics_of(js) != 0) {
+                        early++
+                        return false
+                    }
+                    return true
+                }
                 t |> success(pub3 != null, "publishDiagnostics after the superseding didChange")
-                t |> equal(diagnostics_of(pub3), 0, "the superseded broken compile never published")
+                t |> success(early <= 1, "at most the broken compile that finished before the clean edit published")
 
-                // definition at the call site resolves to the def line
+                // definition at the call site resolves to the def line; a stale publish arriving
+                // after the clean one would show up here
                 write_frame(w, sprint_json(DefinitionMsg(id = 2, params = CursorParams(
                     textDocument = DocId(uri = uri),
                     position = Position0(line = call_line0, character = 4))), false))
-                let def_resp = read_until(r) $(js) => (js?["id"] ?? -1) == 2
+                var stale = 0
+                let def_resp = read_until(r) $(js) {
+                    if ((js?["method"] ?? "") == "textDocument/publishDiagnostics" && diagnostics_of(js) != 0) {
+                        stale++
+                    }
+                    return (js?["id"] ?? -1) == 2
+                }
                 t |> success(def_resp != null, "definition response received")
+                t |> equal(stale, 0, "no stale publish after the clean one")
                 let loc0 = def_resp?["result"]?[0]
                 t |> equal(uri_for_compare(loc0?["uri"] ?? ""), uri_for_compare(uri))
                 t |> equal(loc0?["range"]?["start"]?["line"] ?? -1, def_line0)


### PR DESCRIPTION
**Behavior change: the records oracle idles 60 s before every timed das cell (was 12 s) - an oracle board takes longer per box.**

**Why.** The oracle's first read after a big cell lands 20-33% under its stored mean and spends a FAIL and a retry slot. The previous cell's heat outlives the 12 s reclaim settle: on the M5 Max the GPU still runs 990-1420 MHz instead of 1620 when the next cell starts.

**What changes.**
- `--oracle-settle` (default 60) idles before each timed oracle das cell on every leg; the reclaim settle stays 12 s.
- The three sleep-if-positive helpers fold into one `settle(seconds)`; the retry settle goes through it too.
- Ledger row 138 carries the throttle's cause and provenance; row 140 closes the CPU ASR shortfall as core placement on the box, not a code regression.
- Three checklists fix what applying them to this diff surfaced (served-turn and board-cell definitions, figure rules keyed on legs of a turn, diff-scoped records rules, one override boundary, every STYLE037/038 suppression spelling).

**Observable behavior.**
- oracle cell after a big cell reads 20-33% low and retries -> reads within 1% first time
- `--oracle --legs metal` on the M5 board -> about 17 min longer (21 cells x 48 s of idle)

**Where to look.** The three `settle(cfg.oracle_settle)` sites in `performance/gen_bench_records.das` and the two rewritten ledger rows.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full preflight ran once; compile-sweep was red on a stale binary (the LSP watchdog merge added a fio binding after the last build) and passed on the targeted rerun after an incremental rebuild.
- `benchmarks/REVIEW.md` applied by hand to the driver: no instrument, clock, or kernel dispatch is added, so its rules do not fire.

### Claims - stated, not tested
- The `--oracle-settle` arm, its three sites, and the folded `settle` guard have no test: the tool drives model processes for hours and its three sibling knobs carry none either. The measurement stands in: five of five reproductions of the cold read with the board's sequence, 60 s and 120 s settles reading Nominal within 1%. A break would show as an oracle board whose first cell after a big one fails and passes its retry.
- 60 s is the M5 Max's number; the Vulkan boards show the same first-read drop but were not instrumented.

### Not done
- Row 138 keeps the thermal-state wait (`NSProcessInfo.thermalState`) as the unquirk that replaces the fixed number.
- Two lint candidates from the checklist review: a `REVIEW.das` cell for the `records/mtp/` engine-stamp rules, and the `defaults/` version-pin compare in `check_defaults_profiles`.

</details>